### PR TITLE
Run alias and container aliases

### DIFF
--- a/backends.go
+++ b/backends.go
@@ -4,13 +4,15 @@ import (
 	"context"
 
 	"github.com/paradedb/benchmarker/backends"
-	"github.com/paradedb/benchmarker/backends/clickhouse"
-	"github.com/paradedb/benchmarker/backends/elasticsearch"
-	"github.com/paradedb/benchmarker/backends/mongodb"
-	"github.com/paradedb/benchmarker/backends/opensearch"
-	"github.com/paradedb/benchmarker/backends/postgres"
 	"github.com/paradedb/benchmarker/metrics"
 	"go.k6.io/k6/js/modules"
+
+	// Import backends to register them via init()
+	_ "github.com/paradedb/benchmarker/backends/clickhouse"
+	_ "github.com/paradedb/benchmarker/backends/elasticsearch"
+	_ "github.com/paradedb/benchmarker/backends/mongodb"
+	_ "github.com/paradedb/benchmarker/backends/opensearch"
+	_ "github.com/paradedb/benchmarker/backends/postgres"
 )
 
 // Backends holds all configured backend clients.
@@ -36,62 +38,36 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 	containers := backends.DefaultContainers()
 
 	for name, cfg := range config {
+		alias := parseAlias(cfg)
+		container := parseContainer(cfg, containers[name], alias)
+		opts := backends.K6ClientOptions{Container: container, Alias: alias}
+		conn := parseConn(cfg, defaults[name])
+
+		driver, err := backends.NewDriver(name, conn)
+		if err != nil {
+			continue
+		}
+
+		client := backends.NewK6Client(m.vu, driver, name, opts)
+		enabledContainers = append(enabledContainers, container)
+		driver.CaptureConfig(ctx, name)
+
+		// Assign to named fields for JS API compatibility
 		switch name {
 		case "paradedb":
-			conn := parseConn(cfg, defaults["paradedb"])
-			if driver, err := postgres.New(conn); err == nil {
-				b.Paradedb = backends.NewK6Client(m.vu, driver, "paradedb")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["paradedb"]))
-				driver.CaptureConfig(ctx, "paradedb")
-			}
-
+			b.Paradedb = client
 		case "postgres-fts":
-			conn := parseConn(cfg, defaults["postgres-fts"])
-			if driver, err := postgres.New(conn); err == nil {
-				b.PgFTS = backends.NewK6Client(m.vu, driver, "postgres-fts")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["postgres-fts"]))
-				driver.CaptureConfig(ctx, "postgres-fts")
-			}
-
+			b.PgFTS = client
 		case "pg-textsearch":
-			conn := parseConn(cfg, defaults["pg-textsearch"])
-			if driver, err := postgres.New(conn); err == nil {
-				b.Textsearch = backends.NewK6Client(m.vu, driver, "pg-textsearch")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["pg-textsearch"]))
-				driver.CaptureConfig(ctx, "pg-textsearch")
-			}
-
+			b.Textsearch = client
 		case "elasticsearch":
-			conn := parseConn(cfg, defaults["elasticsearch"])
-			if driver, err := elasticsearch.New(conn); err == nil {
-				b.Elastic = backends.NewK6Client(m.vu, driver, "elasticsearch")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["elasticsearch"]))
-				driver.CaptureConfig(ctx, "elasticsearch")
-			}
-
+			b.Elastic = client
 		case "opensearch":
-			conn := parseConn(cfg, defaults["opensearch"])
-			if driver, err := opensearch.New(conn); err == nil {
-				b.OpenSearch = backends.NewK6Client(m.vu, driver, "opensearch")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["opensearch"]))
-				driver.CaptureConfig(ctx, "opensearch")
-			}
-
+			b.OpenSearch = client
 		case "clickhouse":
-			conn := parseConn(cfg, defaults["clickhouse"])
-			if driver, err := clickhouse.New(conn); err == nil {
-				b.Click = backends.NewK6Client(m.vu, driver, "clickhouse")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["clickhouse"]))
-				driver.CaptureConfig(ctx, "clickhouse")
-			}
-
+			b.Click = client
 		case "mongodb":
-			conn := parseConn(cfg, defaults["mongodb"])
-			if driver, err := mongodb.New(conn); err == nil {
-				b.Mongo = backends.NewK6Client(m.vu, driver, "mongodb")
-				enabledContainers = append(enabledContainers, parseContainer(cfg, containers["mongodb"]))
-				driver.CaptureConfig(ctx, "mongodb")
-			}
+			b.Mongo = client
 		}
 	}
 
@@ -133,13 +109,28 @@ func parseConn(cfg interface{}, defaultConn string) string {
 }
 
 // parseContainer extracts container name from config, or returns default.
-func parseContainer(cfg interface{}, defaultContainer string) string {
+// If alias is provided and container is not, container defaults to alias.
+func parseContainer(cfg interface{}, defaultContainer string, alias string) string {
 	if m, ok := cfg.(map[string]interface{}); ok {
 		if c, ok := m["container"].(string); ok {
 			return c
 		}
 	}
+	// Default container to alias if alias is set
+	if alias != "" {
+		return alias
+	}
 	return defaultContainer
+}
+
+// parseAlias extracts alias name from config.
+func parseAlias(cfg interface{}) string {
+	if m, ok := cfg.(map[string]interface{}); ok {
+		if a, ok := m["alias"].(string); ok {
+			return a
+		}
+	}
+	return ""
 }
 
 // Collect collects metrics from all enabled containers.

--- a/backends/driver.go
+++ b/backends/driver.go
@@ -151,15 +151,28 @@ type DriverFactory func(connString string) (Driver, error)
 
 // K6Client wraps a Driver with k6 metrics emission.
 type K6Client struct {
-	driver  Driver
-	vu      modules.VU
-	backend string
+	driver    Driver
+	vu        modules.VU
+	backend   string
+	container string
+	alias     string
+}
+
+// K6ClientOptions configures a K6Client.
+type K6ClientOptions struct {
+	Container string
+	Alias     string
 }
 
 // NewK6Client creates a k6 client that wraps a driver.
-func NewK6Client(vu modules.VU, driver Driver, backend string) *K6Client {
+func NewK6Client(vu modules.VU, driver Driver, backend string, opts ...K6ClientOptions) *K6Client {
 	metrics.RegisterMetrics(vu)
-	return &K6Client{driver: driver, vu: vu, backend: backend}
+	c := &K6Client{driver: driver, vu: vu, backend: backend}
+	if len(opts) > 0 {
+		c.container = opts[0].Container
+		c.alias = opts[0].Alias
+	}
+	return c
 }
 
 // Search executes a query and emits metrics.
@@ -191,7 +204,7 @@ func (c *K6Client) Search(query string, args ...any) map[string]interface{} {
 	}
 
 	result := &metrics.SearchResult{Hits: int64(hits), LatencyMs: latencyMs}
-	result.Emit(ctx, c.vu, c.backend)
+	result.Emit(ctx, c.vu, c.backend, metrics.EmitOptions{Container: c.container, Alias: c.alias})
 	return result.ToMap()
 }
 
@@ -232,7 +245,7 @@ func (c *K6Client) InsertBatch(table string, docs []map[string]interface{}) map[
 	}
 
 	result := &metrics.IngestResult{Rows: count, LatencyMs: latencyMs}
-	result.Emit(ctx, c.vu, c.backend)
+	result.Emit(ctx, c.vu, c.backend, metrics.EmitOptions{Container: c.container, Alias: c.alias})
 	return result.ToMap()
 }
 

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -51,7 +51,8 @@ type DashboardData struct {
 type RunMetrics struct {
 	Name           string                   `json:"name"`
 	Backend        string                   `json:"backend"`   // Backend type: paradedb, elasticsearch, clickhouse, mongodb, etc.
-	Container      string                   `json:"container"`
+	Container      string                   `json:"container"` // Docker container name for resource metrics
+	Alias          string                   `json:"alias"`     // User-defined alias for this backend instance
 	Latencies      []float64                `json:"latencies"`
 	Timeline       []TimelinePoint          `json:"timeline"`
 	CPU            []TimeValue              `json:"cpu"`
@@ -196,8 +197,11 @@ func (o *Output) flush() {
 
 			switch {
 			case name == "search_duration":
-				// Get run from tags (prefer backend, then run, then scenario)
-				run := tags["backend"]
+				// Get run identifier: prefer alias, then backend, then run, then scenario
+				run := tags["alias"]
+				if run == "" {
+					run = tags["backend"]
+				}
 				if run == "" {
 					run = tags["run"]
 				}
@@ -214,13 +218,20 @@ func (o *Output) flush() {
 						Name:      run,
 						Backend:   tags["backend"],
 						Container: tags["container"],
+						Alias:     tags["alias"],
 						Queries:   make(map[string]*QueryMetrics),
 					}
 				}
-				// Update backend if provided and not yet set
+				// Update backend/container/alias if provided and not yet set
 				rm := o.data.Runs[run]
 				if rm.Backend == "" && tags["backend"] != "" {
 					rm.Backend = tags["backend"]
+				}
+				if rm.Container == "" && tags["container"] != "" {
+					rm.Container = tags["container"]
+				}
+				if rm.Alias == "" && tags["alias"] != "" {
+					rm.Alias = tags["alias"]
 				}
 				rm.Latencies = append(rm.Latencies, value)
 				if rm.StartTime == 0 {
@@ -256,8 +267,11 @@ func (o *Output) flush() {
 				}
 
 			case name == "ingest_docs":
-				// Get run from tags (prefer backend, then run, then scenario)
-				run := tags["backend"]
+				// Get run identifier: prefer alias, then backend, then run, then scenario
+				run := tags["alias"]
+				if run == "" {
+					run = tags["backend"]
+				}
 				if run == "" {
 					run = tags["run"]
 				}
@@ -273,12 +287,19 @@ func (o *Output) flush() {
 						Name:      run,
 						Backend:   tags["backend"],
 						Container: tags["container"],
+						Alias:     tags["alias"],
 						Queries:   make(map[string]*QueryMetrics),
 					}
 				}
 				rm := o.data.Runs[run]
 				if rm.Backend == "" && tags["backend"] != "" {
 					rm.Backend = tags["backend"]
+				}
+				if rm.Container == "" && tags["container"] != "" {
+					rm.Container = tags["container"]
+				}
+				if rm.Alias == "" && tags["alias"] != "" {
+					rm.Alias = tags["alias"]
 				}
 				rm.TotalIngested += int64(value)
 				if rm.StartTime == 0 {
@@ -373,7 +394,12 @@ func (o *Output) findActiveRunForContainer(container string) *RunMetrics {
 			continue
 		}
 
-		// Match using backend tag
+		// First, try exact match on container name (handles custom containers and aliases)
+		if rm.Container == container {
+			return rm
+		}
+
+		// Fall back to matching container name against backend type
 		if rm.Backend != "" && containerMatchesBackend(container, rm.Backend) {
 			if rm.Container == "" {
 				rm.Container = container
@@ -554,12 +580,13 @@ func (o *Output) getSummary() map[string]interface{} {
 		}
 
 		// Add database config based on backend tag
-		config, containerLimits := getBackendConfig(rm.Backend)
+		config, containerLimits := getBackendConfig(rm.Backend, rm.Container)
 
 		runs[name] = map[string]interface{}{
 			"name":            rm.Name,
 			"backend":         rm.Backend,
 			"container":       rm.Container,
+			"alias":           rm.Alias,
 			"cpu":             rm.CPU,
 			"memory":          rm.Memory,
 			"ingestRate":      rm.IngestRate,
@@ -688,11 +715,18 @@ func getQueryPattern(qName string) string {
 }
 
 // getBackendConfig returns the database config and container limits for a backend type.
-func getBackendConfig(backend string) (map[string]interface{}, map[string]interface{}) {
+// Container limits are looked up by container name, not backend name.
+func getBackendConfig(backend, container string) (map[string]interface{}, map[string]interface{}) {
 	if backend == "" {
 		return nil, nil
 	}
-	return metrics.GetBackendConfig(backend), metrics.ContainerLimits[backend]
+	// Look up limits by container name (which may be alias or custom container name)
+	limits := metrics.ContainerLimits[container]
+	if limits == nil && container != backend {
+		// Fall back to backend name for backwards compatibility
+		limits = metrics.ContainerLimits[backend]
+	}
+	return metrics.GetBackendConfig(backend), limits
 }
 
 // ServeFile starts a server to view a saved dashboard JSON file.

--- a/metrics/results.go
+++ b/metrics/results.go
@@ -69,8 +69,14 @@ type SearchResult struct {
 	Error     string
 }
 
+// EmitOptions contains optional tags for metric emission.
+type EmitOptions struct {
+	Container string
+	Alias     string
+}
+
 // Emit pushes search metrics to k6 with the backend tag.
-func (r *SearchResult) Emit(ctx context.Context, vu modules.VU, backend string) {
+func (r *SearchResult) Emit(ctx context.Context, vu modules.VU, backend string, opts ...EmitOptions) {
 	if r.Error != "" {
 		return // Don't emit metrics on error
 	}
@@ -84,6 +90,16 @@ func (r *SearchResult) Emit(ctx context.Context, vu modules.VU, backend string) 
 	tags := state.Tags.GetCurrentValues().Tags
 	if backend != "" {
 		tags = tags.With("backend", backend)
+	}
+
+	// Add container and alias tags if provided
+	if len(opts) > 0 {
+		if opts[0].Container != "" {
+			tags = tags.With("container", opts[0].Container)
+		}
+		if opts[0].Alias != "" {
+			tags = tags.With("alias", opts[0].Alias)
+		}
 	}
 
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
@@ -118,7 +134,7 @@ type IngestResult struct {
 }
 
 // Emit pushes ingest metrics to k6 with the backend tag.
-func (r *IngestResult) Emit(ctx context.Context, vu modules.VU, backend string) {
+func (r *IngestResult) Emit(ctx context.Context, vu modules.VU, backend string, opts ...EmitOptions) {
 	if r.Error != "" {
 		return // Don't emit metrics on error
 	}
@@ -132,6 +148,16 @@ func (r *IngestResult) Emit(ctx context.Context, vu modules.VU, backend string) 
 	tags := state.Tags.GetCurrentValues().Tags
 	if backend != "" {
 		tags = tags.With("backend", backend)
+	}
+
+	// Add container and alias tags if provided
+	if len(opts) > 0 {
+		if opts[0].Container != "" {
+			tags = tags.With("container", opts[0].Container)
+		}
+		if opts[0].Alias != "" {
+			tags = tags.With("alias", opts[0].Alias)
+		}
 	}
 
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{


### PR DESCRIPTION
- allow a run to be aliased. Allows comparing two backends of the same type
- allow container name to be overridden