### PR TITLE
chore: Fix critical audit issues: dashboard races and broken sample queries

### DIFF
--- a/backends/mongodb/driver.go
+++ b/backends/mongodb/driver.go
@@ -4,6 +4,7 @@ package mongodb
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -53,7 +54,9 @@ func New(connString string) (backends.Driver, error) {
 	}
 
 	if err := client.Ping(ctx, nil); err != nil {
-		client.Disconnect(ctx)
+		if disconnectErr := client.Disconnect(ctx); disconnectErr != nil {
+			return nil, fmt.Errorf("ping failed: %w (disconnect failed: %v)", err, disconnectErr)
+		}
 		return nil, err
 	}
 
@@ -89,7 +92,9 @@ func (d *Driver) Exec(ctx context.Context, statements string) error {
 
 	// Handle drop
 	if drop, ok := config["drop"].(bool); ok && drop {
-		coll.Drop(ctx)
+		if err := coll.Drop(ctx); err != nil && !strings.Contains(err.Error(), "ns not found") && !strings.Contains(err.Error(), "NamespaceNotFound") {
+			return err
+		}
 	}
 
 	// Handle search index creation
@@ -131,7 +136,12 @@ func (d *Driver) waitForSearchIndex(ctx context.Context, coll *mongo.Collection,
 		}
 
 		var indexes []bson.M
-		cursor.All(ctx, &indexes)
+		if err := cursor.All(ctx, &indexes); err != nil {
+			_ = cursor.Close(ctx)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		_ = cursor.Close(ctx)
 
 		for _, idx := range indexes {
 			if idx["name"] == indexName && idx["status"] == "READY" {

--- a/backends/shared/elastic/driver.go
+++ b/backends/shared/elastic/driver.go
@@ -71,7 +71,11 @@ func (d *Driver) Exec(ctx context.Context, statements string) error {
 func (d *Driver) createIndex(ctx context.Context, index string, config map[string]interface{}) error {
 	// Delete existing index
 	req, _ := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/%s", d.address, index), nil)
-	d.client.Do(req)
+	resp, err := d.client.Do(req)
+	if err == nil && resp != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
 
 	// Remove "index" key before sending - it's only used for routing
 	delete(config, "index")
@@ -81,7 +85,7 @@ func (d *Driver) createIndex(ctx context.Context, index string, config map[strin
 	req, _ = http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s", d.address, index), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.client.Do(req)
+	resp, err = d.client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -214,7 +214,9 @@ func (o *Output) Stop() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	o.server.Shutdown(ctx)
+	if err := o.server.Shutdown(ctx); err != nil && err != http.ErrServerClosed {
+		return err
+	}
 
 	return nil
 }
@@ -710,7 +712,9 @@ func (o *Output) handleData(w http.ResponseWriter, r *http.Request) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
-	json.NewEncoder(w).Encode(o.getSummary())
+	if err := json.NewEncoder(w).Encode(o.getSummary()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func percentile(values []float64, p float64) float64 {
@@ -815,7 +819,9 @@ func ServeFile(filename string, notes ...string) error {
 	mux.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Write(compactData)
+		if _, err := w.Write(compactData); err != nil {
+			return
+		}
 	})
 
 	server := &http.Server{

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -295,7 +295,7 @@ func (o *Output) flush() {
 				queryName := tags["scenario"]
 				if queryName != "" && rm.Queries[queryName] == nil {
 					rm.Queries[queryName] = &QueryMetrics{Name: queryName}
-					if info := metrics.ScenarioInfos[queryName]; info != nil {
+					if info := metrics.GetScenarioInfo(queryName); info != nil {
 						rm.Queries[queryName].VUs = int(info.VUs)
 						rm.Queries[queryName].Executor = info.Executor
 					}
@@ -333,7 +333,7 @@ func (o *Output) flush() {
 					qm := rm.Queries[queryName]
 					qm.Latencies = append(qm.Latencies, value)
 					if qm.VUs == 0 || qm.Executor == "" {
-						if info := metrics.ScenarioInfos[queryName]; info != nil {
+						if info := metrics.GetScenarioInfo(queryName); info != nil {
 							if qm.VUs == 0 {
 								qm.VUs = int(info.VUs)
 							}
@@ -752,10 +752,7 @@ func maxVal(values []float64) float64 {
 
 // getQueryPattern looks up a query pattern by scenario name.
 func getQueryPattern(qName string) string {
-	if p, ok := metrics.QueryPatterns[qName]; ok {
-		return p
-	}
-	return ""
+	return metrics.GetQueryPattern(qName)
 }
 
 // getBackendConfig returns the database config and container limits for a backend type.
@@ -765,10 +762,10 @@ func getBackendConfig(backend, container string) (map[string]interface{}, map[st
 		return nil, nil
 	}
 	// Look up limits by container name (which may be alias or custom container name)
-	limits := metrics.ContainerLimits[container]
+	limits := metrics.GetContainerLimits(container)
 	if limits == nil && container != backend {
 		// Fall back to backend name for backwards compatibility
-		limits = metrics.ContainerLimits[backend]
+		limits = metrics.GetContainerLimits(backend)
 	}
 	return metrics.GetBackendConfig(backend), limits
 }

--- a/datasets/sample/k6/ingest_with_queries_new.js
+++ b/datasets/sample/k6/ingest_with_queries_new.js
@@ -150,8 +150,8 @@ export function pgSimpleQuery() {
     `
     SELECT id, title
     FROM documents
-    WHERE content @@@ $1
-    ORDER BY paradedb.score(id) DESC
+    WHERE content ||| $1
+    ORDER BY pdb.score(id) DESC
     LIMIT 10
   `,
     term,

--- a/datasets/sample/k6/ingest_with_queries_new.js
+++ b/datasets/sample/k6/ingest_with_queries_new.js
@@ -150,8 +150,8 @@ export function pgSimpleQuery() {
     `
     SELECT id, title
     FROM documents
-    WHERE content ||| $1
-    ORDER BY pdb.score(id) DESC
+    WHERE content @@@ $1
+    ORDER BY paradedb.score(id) DESC
     LIMIT 10
   `,
     term,
@@ -218,7 +218,12 @@ export function clickhouseIngest() {
 // ==================== MongoDB ====================
 export function mongodbSimple() {
   const term = getTerm();
-  backends.get("mongodb").searchText("documents", "content", term);
+  backends.get("mongodb").search(
+    JSON.stringify({
+      text: { query: term, path: ["title", "content"] },
+    }),
+    "documents",
+  );
 }
 
 export function mongodbIngest() {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -349,7 +349,9 @@ func loadWithDriverJSON(driver backends.Driver, tableName, filePath, dataset, ba
 		indexStart := time.Now()
 		postPath := filepath.Join(dataset, backendDir, "post.json")
 		if content, err := readFile(postPath); err == nil {
-			driver.Exec(ctx, content) // Ignore errors for post
+			if err := driver.Exec(ctx, content); err != nil {
+				fmt.Printf("Warning: post file execution failed: %v\n", err)
+			}
 		}
 		indexTime = time.Since(indexStart)
 	}

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -25,7 +25,7 @@ var (
 
 	// Container resource limits (captured once)
 	ContainerLimits   = make(map[string]map[string]interface{})
-	containerLimitsMu sync.Mutex
+	containerLimitsMu sync.RWMutex
 	limitsCapture     = make(map[string]bool)
 
 	// Backend configs (registered by each backend - database settings etc)
@@ -57,6 +57,23 @@ func GetBackendConfig(backend string) map[string]interface{} {
 	backendConfigsMu.RLock()
 	defer backendConfigsMu.RUnlock()
 	return backendConfigs[backend]
+}
+
+// GetContainerLimits returns captured container limits by container name.
+func GetContainerLimits(container string) map[string]interface{} {
+	containerLimitsMu.RLock()
+	defer containerLimitsMu.RUnlock()
+
+	limits := ContainerLimits[container]
+	if limits == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{}, len(limits))
+	for k, v := range limits {
+		result[k] = v
+	}
+	return result
 }
 
 // CapturePrePostScripts reads pre/post scripts from the dataset directory

--- a/metrics/results.go
+++ b/metrics/results.go
@@ -36,6 +36,25 @@ type ScenarioInfo struct {
 	VUs      int64
 }
 
+// GetQueryPattern returns a query pattern by scenario name.
+func GetQueryPattern(scenario string) string {
+	queryPatternsMu.RLock()
+	defer queryPatternsMu.RUnlock()
+	return QueryPatterns[scenario]
+}
+
+// GetScenarioInfo returns scenario metadata by name.
+func GetScenarioInfo(scenario string) *ScenarioInfo {
+	scenarioInfosMu.RLock()
+	defer scenarioInfosMu.RUnlock()
+	info := ScenarioInfos[scenario]
+	if info == nil {
+		return nil
+	}
+	copy := *info
+	return &copy
+}
+
 // RegisterMetrics registers the unified metrics once during init phase.
 // Call this from any backend's NewClient during init.
 func RegisterMetrics(vu modules.VU) {


### PR DESCRIPTION
## Summary
- fix concurrent map read/write risk in dashboard output by adding locked accessors in metrics package
- update dashboard to use thread-safe getters for scenario info, query patterns, and container limits
- fix broken sample benchmark queries in datasets/sample/k6/ingest_with_queries_new.js (Mongo query API)

## Validation
- gofmt on modified Go files
- static review of updated JS/Go call paths

## Notes
- full go test could not run in this sandbox due blocked dependency network access