### PR TITLE
chore: Fix high-priority audit issues in loader and backend drivers

### DIFF
--- a/backends/driver.go
+++ b/backends/driver.go
@@ -411,6 +411,12 @@ func (l *CLILoader) Load(ctx context.Context, schema *Schema, csvPath string, ba
 	if err := l.ensureDriver(); err != nil {
 		return 0, err
 	}
+	if workers < 1 {
+		workers = 1
+	}
+	if batchSize < 1 {
+		batchSize = 1
+	}
 
 	file, err := os.Open(csvPath)
 	if err != nil {
@@ -437,51 +443,200 @@ func (l *CLILoader) Load(ctx context.Context, schema *Schema, csvPath string, ba
 			cols = append(cols, col)
 		}
 	}
+	if len(cols) == 0 {
+		return 0, fmt.Errorf("no schema columns matched CSV headers")
+	}
 
 	target := schema.Table
+	if target == "" {
+		target = "documents"
+	}
 
+	// Reuse loader driver for worker 0 and create additional drivers as needed.
+	drivers := make([]Driver, 0, workers)
+	drivers = append(drivers, l.driver)
+	for i := 1; i < workers; i++ {
+		d, err := l.factory(l.connString)
+		if err != nil {
+			for j := 1; j < len(drivers); j++ {
+				drivers[j].Close()
+			}
+			return 0, err
+		}
+		drivers = append(drivers, d)
+	}
+	defer func() {
+		for i := 1; i < len(drivers); i++ {
+			drivers[i].Close()
+		}
+	}()
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	batchCh := make(chan [][]any, workers*2)
+	var wg sync.WaitGroup
+	var totalMu sync.Mutex
 	total := 0
-	batch := make([][]any, 0, batchSize)
+	var firstErr error
+	var errOnce sync.Once
+	setErr := func(e error) {
+		if e == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = e
+			cancel()
+		})
+	}
 
+	for _, d := range drivers {
+		driver := d
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for rows := range batchCh {
+				n, err := driver.Insert(workerCtx, target, cols, rows)
+				if err != nil {
+					setErr(err)
+					return
+				}
+				totalMu.Lock()
+				total += n
+				totalMu.Unlock()
+			}
+		}()
+	}
+
+	sendBatch := func(rows [][]any) bool {
+		if len(rows) == 0 {
+			return true
+		}
+		rowsCopy := make([][]any, len(rows))
+		copy(rowsCopy, rows)
+		select {
+		case <-workerCtx.Done():
+			return false
+		case batchCh <- rowsCopy:
+			return true
+		}
+	}
+
+	batch := make([][]any, 0, batchSize)
 	for {
 		record, err := reader.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return total, err
+			setErr(err)
+			break
 		}
 
 		row := make([]any, len(cols))
 		for i, col := range cols {
-			row[i] = convertValue(record[headerIdx[col]], schema.Columns[col])
+			idx, ok := headerIdx[col]
+			if !ok || idx >= len(record) {
+				row[i] = nil
+				continue
+			}
+			row[i] = convertValue(record[idx], schema.Columns[col])
 		}
 		batch = append(batch, row)
 
 		if len(batch) >= batchSize {
-			n, err := l.driver.Insert(ctx, target, cols, batch)
-			if err != nil {
-				return total, err
+			if !sendBatch(batch) {
+				break
 			}
-			total += n
-			batch = batch[:0]
+			batch = make([][]any, 0, batchSize)
 		}
 	}
 
-	if len(batch) > 0 {
-		n, err := l.driver.Insert(ctx, target, cols, batch)
-		if err != nil {
-			return total, err
-		}
-		total += n
+	if firstErr == nil && len(batch) > 0 {
+		sendBatch(batch)
+	}
+	close(batchCh)
+	wg.Wait()
+
+	if firstErr != nil {
+		return total, firstErr
+	}
+	if workerCtx.Err() != nil && workerCtx.Err() != context.Canceled {
+		return total, workerCtx.Err()
 	}
 
 	return total, nil
 }
 
+func safeSQLIdentifier(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty identifier")
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		isLower := c >= 'a' && c <= 'z'
+		isUpper := c >= 'A' && c <= 'Z'
+		isDigit := c >= '0' && c <= '9'
+		isUnderscore := c == '_'
+		if i == 0 {
+			if !(isLower || isUpper || isUnderscore) {
+				return "", fmt.Errorf("invalid identifier: %q", name)
+			}
+		} else if !(isLower || isUpper || isDigit || isUnderscore) {
+			return "", fmt.Errorf("invalid identifier: %q", name)
+		}
+	}
+	return name, nil
+}
+
 func (l *CLILoader) Drop(ctx context.Context, schema *Schema) error {
-	// Drop is handled by pre.sql/pre.json now
-	return nil
+	if err := l.ensureDriver(); err != nil {
+		return err
+	}
+
+	target := "documents"
+	if schema != nil && schema.Table != "" {
+		target = schema.Table
+	}
+
+	switch l.fileType {
+	case "sql":
+		table, err := safeSQLIdentifier(target)
+		if err != nil {
+			return err
+		}
+		return l.driver.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", table))
+	case "json":
+		switch l.name {
+		case "elasticsearch", "opensearch":
+			ops := []map[string]interface{}{
+				{
+					"method": "DELETE",
+					"index":  target,
+				},
+			}
+			data, err := json.Marshal(ops)
+			if err != nil {
+				return err
+			}
+			return l.driver.Exec(ctx, string(data))
+		case "mongodb":
+			cfg := map[string]interface{}{
+				"database":   "benchmark",
+				"collection": target,
+				"drop":       true,
+			}
+			data, err := json.Marshal(cfg)
+			if err != nil {
+				return err
+			}
+			return l.driver.Exec(ctx, string(data))
+		default:
+			return fmt.Errorf("drop not supported for backend %s", l.name)
+		}
+	default:
+		return fmt.Errorf("unsupported backend file type %s", l.fileType)
+	}
 }
 
 func (l *CLILoader) Close() error {

--- a/backends/mongodb/driver.go
+++ b/backends/mongodb/driver.go
@@ -30,13 +30,20 @@ type Driver struct {
 	database string
 }
 
+func isLocalMongoURI(connString string) bool {
+	lower := strings.ToLower(connString)
+	return strings.Contains(lower, "localhost") ||
+		strings.Contains(lower, "127.0.0.1") ||
+		strings.Contains(lower, "::1")
+}
+
 // New creates a new MongoDB driver.
 func New(connString string) (backends.Driver, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Add directConnection for local development
-	if !strings.Contains(connString, "directConnection") {
+	// Add directConnection only for local development (single-node/local Docker).
+	if !strings.Contains(strings.ToLower(connString), "directconnection") && isLocalMongoURI(connString) {
 		if strings.Contains(connString, "?") {
 			connString += "&directConnection=true"
 		} else {

--- a/backends/mongodb/driver.go
+++ b/backends/mongodb/driver.go
@@ -4,6 +4,7 @@ package mongodb
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -60,7 +61,9 @@ func New(connString string) (backends.Driver, error) {
 	}
 
 	if err := client.Ping(ctx, nil); err != nil {
-		client.Disconnect(ctx)
+		if disconnectErr := client.Disconnect(ctx); disconnectErr != nil {
+			return nil, fmt.Errorf("ping failed: %w (disconnect failed: %v)", err, disconnectErr)
+		}
 		return nil, err
 	}
 
@@ -96,7 +99,9 @@ func (d *Driver) Exec(ctx context.Context, statements string) error {
 
 	// Handle drop
 	if drop, ok := config["drop"].(bool); ok && drop {
-		coll.Drop(ctx)
+		if err := coll.Drop(ctx); err != nil && !strings.Contains(err.Error(), "NamespaceNotFound") {
+			return err
+		}
 	}
 
 	// Handle search index creation
@@ -138,7 +143,11 @@ func (d *Driver) waitForSearchIndex(ctx context.Context, coll *mongo.Collection,
 		}
 
 		var indexes []bson.M
-		cursor.All(ctx, &indexes)
+		if err := cursor.All(ctx, &indexes); err != nil {
+			_ = cursor.Close(ctx)
+			time.Sleep(2 * time.Second)
+			continue
+		}
 
 		for _, idx := range indexes {
 			if idx["name"] == indexName && idx["status"] == "READY" {

--- a/backends/postgresfts/register.go
+++ b/backends/postgresfts/register.go
@@ -10,7 +10,7 @@ func init() {
 	backends.Register("postgresfts", backends.BackendConfig{
 		Factory:     postgres.New,
 		FileType:    "sql",
-		EnvVar:      "POSTGRESFTS_URL",
+		EnvVar:      "POSTGRES_FTS_URL",
 		DefaultConn: "postgres://postgres:postgres@localhost:5433/benchmark",
 		Container:   "postgresfts",
 	})

--- a/backends/shared/elastic/driver.go
+++ b/backends/shared/elastic/driver.go
@@ -74,7 +74,7 @@ func (d *Driver) createIndex(ctx context.Context, index string, config map[strin
 	req, _ := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/%s", d.address, index), nil)
 	resp, err := d.client.Do(req)
 	if err == nil && resp != nil {
-		io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
 			return fmt.Errorf("delete index failed with status %d", resp.StatusCode)
@@ -164,7 +164,7 @@ func (d *Driver) execOperations(ctx context.Context, operations []map[string]int
 			resp.Body.Close()
 			return fmt.Errorf("operation %s %s failed: %s", method, opURL, string(respBody))
 		}
-		io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
 

--- a/backends/shared/elastic/driver.go
+++ b/backends/shared/elastic/driver.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -71,7 +72,14 @@ func (d *Driver) Exec(ctx context.Context, statements string) error {
 func (d *Driver) createIndex(ctx context.Context, index string, config map[string]interface{}) error {
 	// Delete existing index
 	req, _ := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/%s", d.address, index), nil)
-	d.client.Do(req)
+	resp, err := d.client.Do(req)
+	if err == nil && resp != nil {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("delete index failed with status %d", resp.StatusCode)
+		}
+	}
 
 	// Remove "index" key before sending - it's only used for routing
 	delete(config, "index")
@@ -81,7 +89,7 @@ func (d *Driver) createIndex(ctx context.Context, index string, config map[strin
 	req, _ = http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s", d.address, index), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.client.Do(req)
+	resp, err = d.client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -104,32 +112,45 @@ func (d *Driver) execOperations(ctx context.Context, operations []map[string]int
 		}
 
 		endpoint, ok := op["endpoint"].(string)
-		if !ok {
+		if !ok && op["method"] == nil {
 			continue
 		}
 
 		// Build URL with query params
-		url := fmt.Sprintf("%s/%s/%s", d.address, index, endpoint)
+		opURL := fmt.Sprintf("%s/%s", d.address, index)
+		if endpoint != "" {
+			opURL += "/" + strings.TrimPrefix(endpoint, "/")
+		}
 		if params, ok := op["params"].(map[string]interface{}); ok {
-			var queryParts []string
+			query := url.Values{}
 			for k, v := range params {
-				queryParts = append(queryParts, fmt.Sprintf("%s=%v", k, v))
+				query.Set(k, fmt.Sprintf("%v", v))
 			}
-			if len(queryParts) > 0 {
-				url += "?" + strings.Join(queryParts, "&")
+			if encoded := query.Encode(); encoded != "" {
+				opURL += "?" + encoded
 			}
 		}
 
 		// Determine method and body
 		method := "POST"
+		hasExplicitMethod := false
+		if m, ok := op["method"].(string); ok && m != "" {
+			method = strings.ToUpper(m)
+			hasExplicitMethod = true
+		}
 		var bodyReader io.Reader
-		if body, ok := op["body"].(map[string]interface{}); ok {
-			method = "PUT"
-			bodyBytes, _ := json.Marshal(body)
+		if body, ok := op["body"]; ok {
+			if !hasExplicitMethod {
+				method = "PUT"
+			}
+			bodyBytes, err := json.Marshal(body)
+			if err != nil {
+				return fmt.Errorf("failed to marshal operation body: %w", err)
+			}
 			bodyReader = bytes.NewReader(bodyBytes)
 		}
 
-		req, _ := http.NewRequestWithContext(ctx, method, url, bodyReader)
+		req, _ := http.NewRequestWithContext(ctx, method, opURL, bodyReader)
 		if bodyReader != nil {
 			req.Header.Set("Content-Type", "application/json")
 		}
@@ -138,6 +159,12 @@ func (d *Driver) execOperations(ctx context.Context, operations []map[string]int
 		if err != nil {
 			return err
 		}
+		if resp.StatusCode >= 400 {
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return fmt.Errorf("operation %s %s failed: %s", method, opURL, string(respBody))
+		}
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
 

--- a/cmd/loader/main.go
+++ b/cmd/loader/main.go
@@ -169,6 +169,12 @@ func getConnection(name string) string {
 	if val := os.Getenv(cfg.EnvVar); val != "" {
 		return val
 	}
+	// Backward-compatibility for prior postgresfts env var name.
+	if name == "postgresfts" {
+		if val := os.Getenv("POSTGRESFTS_URL"); val != "" {
+			return val
+		}
+	}
 	return cfg.DefaultConn
 }
 
@@ -198,51 +204,69 @@ func runLoad(datasetDir string, backendName string, batchSize int, workers int) 
 	}
 
 	ctx := context.Background()
+	overallFailed := false
 
 	for _, b := range loaders {
-		dir := filepath.Join(datasetDir, b.Name())
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			fmt.Printf("Skipping %s (no config directory)\n", b.Name())
-			continue
-		}
+		func(loader *backends.CLILoader) {
+			defer func() {
+				if err := loader.Close(); err != nil {
+					fmt.Printf("Warning: failed to close %s: %v\n", loader.Name(), err)
+				}
+			}()
 
-		fmt.Printf("\n=== %s ===\n", strings.ToUpper(b.Name()))
+			dir := filepath.Join(datasetDir, loader.Name())
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				fmt.Printf("Skipping %s (no config directory)\n", loader.Name())
+				return
+			}
 
-		// Run pre
-		fmt.Print("Running pre... ")
-		start := time.Now()
-		if err := b.RunPre(ctx, dir, schema); err != nil {
-			fmt.Printf("FAILED: %v\n", err)
-			continue
-		}
-		fmt.Printf("OK (%.2fs)\n", time.Since(start).Seconds())
+			fmt.Printf("\n=== %s ===\n", strings.ToUpper(loader.Name()))
 
-		// Load data
-		if workers > 1 {
-			fmt.Printf("Loading data (batch size: %d, workers: %d)... ", batchSize, workers)
-		} else {
-			fmt.Printf("Loading data (batch size: %d)... ", batchSize)
-		}
-		start = time.Now()
-		count, err := b.Load(ctx, schema, csvPath, batchSize, workers)
-		if err != nil {
-			fmt.Printf("FAILED: %v\n", err)
-			continue
-		}
-		elapsed := time.Since(start).Seconds()
-		rate := float64(count) / elapsed
-		fmt.Printf("OK (%d rows, %.2fs, %.0f rows/sec)\n", count, elapsed, rate)
+			// Run pre
+			fmt.Print("Running pre... ")
+			start := time.Now()
+			if err := loader.RunPre(ctx, dir, schema); err != nil {
+				fmt.Printf("FAILED: %v\n", err)
+				overallFailed = true
+				return
+			}
+			fmt.Printf("OK (%.2fs)\n", time.Since(start).Seconds())
 
-		// Run post
-		fmt.Print("Running post... ")
-		start = time.Now()
-		if err := b.RunPost(ctx, dir, schema); err != nil {
-			fmt.Printf("FAILED: %v\n", err)
-			continue
-		}
-		fmt.Printf("OK (%.2fs)\n", time.Since(start).Seconds())
+			// Load data
+			if workers > 1 {
+				fmt.Printf("Loading data (batch size: %d, workers: %d)... ", batchSize, workers)
+			} else {
+				fmt.Printf("Loading data (batch size: %d)... ", batchSize)
+			}
+			start = time.Now()
+			count, err := loader.Load(ctx, schema, csvPath, batchSize, workers)
+			if err != nil {
+				fmt.Printf("FAILED: %v\n", err)
+				overallFailed = true
+				return
+			}
+			elapsed := time.Since(start).Seconds()
+			rate := 0.0
+			if elapsed > 0 {
+				rate = float64(count) / elapsed
+			}
+			fmt.Printf("OK (%d rows, %.2fs, %.0f rows/sec)\n", count, elapsed, rate)
 
-		b.Close()
+			// Run post
+			fmt.Print("Running post... ")
+			start = time.Now()
+			if err := loader.RunPost(ctx, dir, schema); err != nil {
+				fmt.Printf("FAILED: %v\n", err)
+				overallFailed = true
+				return
+			}
+			fmt.Printf("OK (%.2fs)\n", time.Since(start).Seconds())
+		}(b)
+	}
+
+	if overallFailed {
+		fmt.Println("\nCompleted with errors.")
+		os.Exit(1)
 	}
 
 	fmt.Println("\nDone!")

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -214,7 +214,9 @@ func (o *Output) Stop() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	o.server.Shutdown(ctx)
+	if err := o.server.Shutdown(ctx); err != nil && err != http.ErrServerClosed {
+		return err
+	}
 
 	return nil
 }
@@ -710,7 +712,9 @@ func (o *Output) handleData(w http.ResponseWriter, r *http.Request) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 
-	json.NewEncoder(w).Encode(o.getSummary())
+	if err := json.NewEncoder(w).Encode(o.getSummary()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func percentile(values []float64, p float64) float64 {
@@ -818,7 +822,9 @@ func ServeFile(filename string, notes ...string) error {
 	mux.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Write(compactData)
+		if _, err := w.Write(compactData); err != nil {
+			return
+		}
 	})
 
 	server := &http.Server{

--- a/datasets/sample/k6/ingest_with_queries_new.js
+++ b/datasets/sample/k6/ingest_with_queries_new.js
@@ -22,9 +22,7 @@ const terms = new SharedArray("search_terms", function () {
 });
 
 // Load documents once on Go side - shared across all VUs
-const DATA_FILE =
-  __ENV.DATA_FILE ||
-  "/Users/jamesblackwood-sewell/ParadeDB-vs-ElasticSearch/data/documents_small.json";
+const DATA_FILE = __ENV.DATA_FILE || "../data.csv";
 const docs = loader.openDocuments(DATA_FILE);
 
 // Ingest batch size

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -349,7 +349,9 @@ func loadWithDriverJSON(driver backends.Driver, tableName, filePath, dataset, ba
 		indexStart := time.Now()
 		postPath := filepath.Join(dataset, backendDir, "post.json")
 		if content, err := readFile(postPath); err == nil {
-			driver.Exec(ctx, content) // Ignore errors for post
+			if err := driver.Exec(ctx, content); err != nil {
+				return map[string]interface{}{"error": fmt.Sprintf("post.json failed: %v", err)}
+			}
 		}
 		indexTime = time.Since(indexStart)
 	}


### PR DESCRIPTION
## Summary
- implement real multi-worker loading in CLI loader paths and make --workers functional
- implement backend drop behavior instead of no-op for SQL, Elasticsearch/OpenSearch, and MongoDB backends
- fix postgresfts env var name mismatch (POSTGRES_FTS_URL) with backward compatibility in loader CLI
- harden elastic/opensearch operation execution with URL-encoded params, HTTP status checks, and response body handling
- limit MongoDB directConnection=true to local URIs only
- make runLoad fail-fast on backend failures while still closing resources
- replace machine-specific DATA_FILE default in sample ingest script with dataset-relative CSV default

## Validation
- gofmt on modified Go files
- static review of worker/drop/error paths

## Notes
- full go test could not run in this sandbox due blocked dependency network access