### PR TITLE
chore: Low-priority audit fixes for CLI robustness and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build k6 loader clean test fmt lint deps help
+.PHONY: all build k6 loader viewer clean test fmt lint deps help
 
 GOBIN := $(shell go env GOPATH)/bin
 XK6 := $(GOBIN)/xk6

--- a/cmd/dashboard-viewer/main.go
+++ b/cmd/dashboard-viewer/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/paradedb/benchmarks/dashboard"
 )
@@ -33,17 +34,32 @@ func main() {
 	// Parse flags
 	var exportFile, notes string
 	for i := 2; i < len(os.Args); i++ {
-		switch os.Args[i] {
+		arg := os.Args[i]
+		switch arg {
 		case "--export":
 			if i+1 < len(os.Args) {
 				exportFile = os.Args[i+1]
 				i++
+			} else {
+				fmt.Println("Error: --export requires a file path")
+				os.Exit(1)
 			}
 		case "--notes":
 			if i+1 < len(os.Args) {
 				notes = os.Args[i+1]
 				i++
+			} else {
+				fmt.Println("Error: --notes requires a value")
+				os.Exit(1)
 			}
+		default:
+			if strings.HasPrefix(arg, "-") {
+				fmt.Printf("Error: unknown flag: %s\n", arg)
+			} else {
+				fmt.Printf("Error: unexpected argument: %s\n", arg)
+			}
+			fmt.Println("Usage: dashboard-viewer <dashboard.json> [--export <output.html>] [--notes \"Description\"]")
+			os.Exit(1)
 		}
 	}
 

--- a/cmd/loader/main_test.go
+++ b/cmd/loader/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import "testing"
+
+func TestParseS3URL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantBucket string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{
+			name:       "bucket and prefix",
+			url:        "s3://my-bucket/datasets/sample/",
+			wantBucket: "my-bucket",
+			wantPrefix: "datasets/sample",
+		},
+		{
+			name:       "bucket only",
+			url:        "s3://my-bucket",
+			wantBucket: "my-bucket",
+			wantPrefix: "",
+		},
+		{
+			name:    "invalid scheme",
+			url:     "https://example.com/bucket",
+			wantErr: true,
+		},
+		{
+			name:    "missing bucket",
+			url:     "s3://",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, prefix, err := parseS3URL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.url)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if bucket != tt.wantBucket {
+				t.Fatalf("bucket mismatch: got %q, want %q", bucket, tt.wantBucket)
+			}
+			if prefix != tt.wantPrefix {
+				t.Fatalf("prefix mismatch: got %q, want %q", prefix, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{bytes: 0, want: "0 B"},
+		{bytes: 1023, want: "1023 B"},
+		{bytes: 1024, want: "1.0 KB"},
+		{bytes: 1536, want: "1.5 KB"},
+		{bytes: 1048576, want: "1.0 MB"},
+	}
+
+	for _, tt := range tests {
+		got := formatBytes(tt.bytes)
+		if got != tt.want {
+			t.Fatalf("formatBytes(%d) = %q, want %q", tt.bytes, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add viewer to Makefile .PHONY targets
- harden cmd/dashboard-viewer flag parsing with explicit errors for unknown flags, unexpected args, and missing values
- add loader unit tests for parseS3URL and formatBytes

## Testing
- gofmt -w cmd/dashboard-viewer/main.go cmd/loader/main_test.go
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./cmd/loader ./cmd/dashboard-viewer (fails in sandbox due blocked network access to proxy.golang.org for module downloads)
