### PR TITLE
chore: Follow-up audit fixes for docs consistency and config errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ export function searchQuery() {
   backends
     .get("paradedb")
     .search(
-      `SELECT id, title FROM documents WHERE content @@@ $1 LIMIT 10`,
+      `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
       term,
     );
 }
@@ -262,9 +262,9 @@ DASHBOARD_EXPORT=true ./k6 run --out dashboard benchmark.js
 ```javascript
 backends.get("paradedb").search(
   `
-  SELECT id, title, paradedb.score(id) as score
+  SELECT id, title, pdb.score(id) as score
   FROM documents
-  WHERE content @@@ $1
+  WHERE content ||| $1
   ORDER BY score DESC
   LIMIT 10
 `,
@@ -401,7 +401,7 @@ datasets/
 ```yaml
 table: documents
 columns:
-  id: bigint
+  id: uuid
   title: text
   content: text
 ```

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ Then open http://localhost:5665 in your browser.
 # Export dashboard data during run
 DASHBOARD_EXPORT=true ./k6 run --out dashboard benchmark.js
 
-# View saved data later
-./bin/dashboard-viewer ./dashboard-export.json
+# View saved data later (use generated dashboard_<timestamp>.json file)
+./bin/dashboard-viewer ./dashboard_2026-02-28_12-00-00.json
 ```
 
 ## Backend Examples

--- a/backends.go
+++ b/backends.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/paradedb/benchmarks/backends"
 	"github.com/paradedb/benchmarks/metrics"
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 
 	// Import backends to register them via init()
@@ -31,6 +32,17 @@ func (b *Backends) Get(alias string) *backends.K6Client {
 	return b.clients[alias]
 }
 
+func (m *ModuleInstance) configErrorf(format string, args ...interface{}) {
+	err := fmt.Errorf(format, args...)
+	if m.vu != nil {
+		if rt := m.vu.Runtime(); rt != nil {
+			common.Throw(rt, err)
+			return
+		}
+	}
+	panic(err.Error())
+}
+
 // newBackends creates a new backends registry with the specified configuration.
 func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 	b := &Backends{
@@ -47,7 +59,8 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 	// Parse backends array
 	backendsArray, ok := config["backends"].([]interface{})
 	if !ok {
-		panic("backends: 'backends' array is required")
+		m.configErrorf("backends: 'backends' array is required")
+		return nil
 	}
 
 	for _, item := range backendsArray {
@@ -63,7 +76,8 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 			var ok bool
 			backendType, ok = v["type"].(string)
 			if !ok {
-				panic("backends: each backend config must have a 'type' field")
+				m.configErrorf("backends: each backend config must have a 'type' field")
+				return nil
 			}
 			alias = backendType
 			if a, ok := v["alias"].(string); ok {
@@ -79,14 +93,16 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 				conn = c
 			}
 		default:
-			panic("backends: each backend must be a string or object")
+			m.configErrorf("backends: each backend must be a string or object")
+			return nil
 		}
 
 		// Validate backend type
 		backendCfg, ok := backends.GetConfig(backendType)
 		if !ok {
-			panic(fmt.Sprintf("backends: unknown backend type '%s'. Valid types: %v",
-				backendType, backends.RegisteredBackends()))
+			m.configErrorf("backends: unknown backend type '%s'. Valid types: %v",
+				backendType, backends.RegisteredBackends())
+			return nil
 		}
 
 		// Apply defaults
@@ -103,12 +119,14 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 
 		// Check for duplicate alias
 		if _, exists := b.clients[alias]; exists {
-			panic(fmt.Sprintf("backends: duplicate alias '%s'", alias))
+			m.configErrorf("backends: duplicate alias '%s'", alias)
+			return nil
 		}
 
 		driver, err := backends.NewDriver(backendType, conn)
 		if err != nil {
-			panic(fmt.Sprintf("backends: failed to create '%s': %v", alias, err))
+			m.configErrorf("backends: failed to create '%s': %v", alias, err)
+			return nil
 		}
 
 		// Register backend options

--- a/backends/driver.go
+++ b/backends/driver.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -114,8 +115,15 @@ func GetAllCLILoaders(getConnString func(name string) string) []*CLILoader {
 	backendConfigsMu.RLock()
 	defer backendConfigsMu.RUnlock()
 
-	var loaders []*CLILoader
-	for name, cfg := range backendConfigs {
+	names := make([]string, 0, len(backendConfigs))
+	for name := range backendConfigs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	loaders := make([]*CLILoader, 0, len(names))
+	for _, name := range names {
+		cfg := backendConfigs[name]
 		loaders = append(loaders, NewCLILoader(name, cfg.FileType, getConnString(name), cfg.Factory))
 	}
 	return loaders
@@ -130,6 +138,7 @@ func RegisteredBackends() []string {
 	for name := range backendConfigs {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -163,7 +163,7 @@ func New(params output.Params) (output.Output, error) {
 
 // Description returns a human-readable description.
 func (o *Output) Description() string {
-	return "Web Dashboard (http://localhost:5665)"
+	return "Web Dashboard (http://localhost:5665/static/)"
 }
 
 // Start starts the HTTP server.

--- a/datasets/sample/k6/simple.js
+++ b/datasets/sample/k6/simple.js
@@ -49,8 +49,8 @@ export function pgSimpleQuery() {
     `
     SELECT id, title
     FROM documents
-    WHERE content @@@ $1
-    ORDER BY paradedb.score(id) DESC
+    WHERE content ||| $1
+    ORDER BY pdb.score(id) DESC
     LIMIT 10
   `,
     term,


### PR DESCRIPTION
## Summary
- align remaining ParadeDB examples with the syntax used in PR #6 (`|||`, `pdb.score(...)`)
- fix README `schema.yaml` example to match sample dataset UUID ids
- make dashboard URL messaging consistent by returning `/static/` in output description
- make backend enumeration deterministic by sorting in `GetAllCLILoaders()` and `RegisteredBackends()`
- replace hard panics in `search.backends(...)` config validation with k6 JS exceptions via `common.Throw`

## Files
- `datasets/sample/k6/simple.js`
- `README.md`
- `dashboard/output.go`
- `backends/driver.go`
- `backends.go`

## Testing
- `gofmt -w backends.go backends/driver.go`
- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./...` *(fails in sandbox: cannot resolve `proxy.golang.org` for module downloads)*
