### PR TITLE
chore: replace Slack invite link with paradedb.com/slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/paradedb/paradedb/discussions
     about: Please ask and answer general questions here.
   - name: ParadeDB Community Slack
-    url: https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw
+    url: https://paradedb.com/slack
     about: Our Slack community is the best place to get quick help and feedback.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! We're excited that you're interested in contributing and want to make t
 
 ## Technical Info
 
-Before submitting a pull request, please review this document, which outlines what conventions to follow when submitting changes. If you have any questions not covered in this document, please reach out to us in the [ParadeDB Community Slack](https://join.slack.com/t/paradedbcommunity/shared_invite/zt-32abtyjg4-yoYoi~RPh9MSW8tDbl0BQw) or via [email](mailto:support@paradedb.com).
+Before submitting a pull request, please review this document, which outlines what conventions to follow when submitting changes. If you have any questions not covered in this document, please reach out to us in the [ParadeDB Community Slack](https://paradedb.com/slack) or via [email](mailto:support@paradedb.com).
 
 ### Selecting GitHub Issues
 


### PR DESCRIPTION
## Summary
- Replace long Slack invite URL (`join.slack.com/...`) with `https://paradedb.com/slack` redirect

## Test plan
- [ ] Verify `https://paradedb.com/slack` redirects to the Slack invite page