### PR TITLE
fix: Fix dashboard metrics correctness

### DIFF
--- a/backends/driver.go
+++ b/backends/driver.go
@@ -205,7 +205,7 @@ func (c *K6Client) Search(query string, args ...any) map[string]interface{} {
 			}
 		}
 	}
-	metrics.CaptureQueryPattern(c.vu, queryPattern)
+	metrics.CaptureQueryPattern(c.vu, c.backend, queryPattern)
 	metrics.CaptureScenarioInfo(c.vu)
 
 	start := time.Now()
@@ -229,8 +229,6 @@ func (c *K6Client) Search(query string, args ...any) map[string]interface{} {
 // InsertBatch inserts documents and emits metrics.
 func (c *K6Client) InsertBatch(table string, docs []map[string]interface{}) map[string]interface{} {
 	c.emitInitMetrics()
-
-	fmt.Printf("[%s] InsertBatch called: table=%s docs=%d\n", c.backend, table, len(docs))
 
 	if len(docs) == 0 {
 		return map[string]interface{}{"rows": 0, "latencyMs": 0.0}

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -65,22 +65,23 @@ type ContainerMetrics struct {
 
 // RunMetrics holds metrics for a single run/phase.
 type RunMetrics struct {
-	Name           string                   `json:"name"`
-	Backend        string                   `json:"backend"`   // Backend type: paradedb, elasticsearch, clickhouse, mongodb, etc.
-	Container      string                   `json:"container"` // Docker container name for resource metrics
-	Alias          string                   `json:"alias"`     // User-defined alias for this backend instance
-	Color          string                   `json:"color"`     // Custom color for this backend
-	Chart          string                   `json:"chart"`     // Chart group for separating graphs
-	Latencies      []float64                `json:"latencies"`
-	Timeline       []TimelinePoint          `json:"timeline"`
-	IngestRate     []TimeValue              `json:"ingestRate"`    // Docs/sec timeline
-	TotalIngested  int64                    `json:"totalIngested"` // Total docs ingested
-	LastIngestTime int64                    `json:"-"`             // For rate calculation
-	LastIngestDocs int64                    `json:"-"`             // For rate calculation
-	Queries        map[string]*QueryMetrics `json:"-"`             // Per-query breakdown
-	StartTime      int64                    `json:"startTime"`
-	EndTime        int64                    `json:"endTime"`
-	LastUpdateTime int64                    `json:"-"` // Track last update for end detection
+	Name            string                   `json:"name"`
+	Backend         string                   `json:"backend"`   // Backend alias emitted in k6 metric tags
+	Container       string                   `json:"container"` // Docker container name for resource metrics
+	Alias           string                   `json:"alias"`     // User-defined alias for this backend instance
+	Color           string                   `json:"color"`     // Custom color for this backend
+	Chart           string                   `json:"chart"`     // Chart group for separating graphs
+	Latencies       []float64                `json:"latencies"`
+	Timeline        []TimelinePoint          `json:"timeline"`
+	IngestRate      []TimeValue              `json:"ingestRate"`    // Docs/sec timeline
+	TotalIngested   int64                    `json:"totalIngested"` // Total docs ingested
+	FirstIngestTime int64                    `json:"-"`             // Timestamp of the first ingest sample
+	LastIngestTime  int64                    `json:"-"`             // For rate calculation
+	LastIngestDocs  int64                    `json:"-"`             // For rate calculation
+	Queries         map[string]*QueryMetrics `json:"-"`             // Per-query breakdown
+	StartTime       int64                    `json:"startTime"`
+	EndTime         int64                    `json:"endTime"`
+	LastUpdateTime  int64                    `json:"-"` // Track last update for end detection
 }
 
 // QueryMetrics holds metrics for a specific query type within a run.
@@ -91,6 +92,8 @@ type QueryMetrics struct {
 	Latencies []float64       `json:"latencies"`
 	HitCounts []int64         `json:"-"` // Raw hit counts for timeline calculation
 	Timeline  []TimelinePoint `json:"timeline"`
+	StartTime int64           `json:"-"`
+	EndTime   int64           `json:"-"`
 
 	// Timestamps track when each latency sample arrived (parallel to Latencies slice)
 	Timestamps    []int64 `json:"-"`
@@ -367,6 +370,10 @@ func (o *Output) flush() {
 						rm.Queries[queryName] = &QueryMetrics{Name: queryName}
 					}
 					qm := rm.Queries[queryName]
+					if qm.StartTime == 0 {
+						qm.StartTime = sample.Time.UnixMilli()
+					}
+					qm.EndTime = sample.Time.UnixMilli()
 					qm.Latencies = append(qm.Latencies, value)
 					qm.Timestamps = append(qm.Timestamps, now)
 					if qm.VUs == 0 || qm.Executor == "" {
@@ -432,7 +439,6 @@ func (o *Output) flush() {
 				o.data.Containers[container].Memory = append(o.data.Containers[container].Memory, TimeValue{Time: sample.Time.UnixMilli(), Value: value})
 
 			case name == "ingest_docs":
-				fmt.Printf("[dashboard] ingest_docs sample: value=%.0f tags=%v\n", value, tags)
 				backend := tags["backend"]
 				if backend == "" {
 					backend = tags["run"]
@@ -447,6 +453,9 @@ func (o *Output) flush() {
 				runName := getRunName(backend, tags)
 				rm := o.getOrCreateRun(runName, backend, tags)
 				rm.TotalIngested += int64(value)
+				if rm.FirstIngestTime == 0 {
+					rm.FirstIngestTime = sample.Time.UnixMilli()
+				}
 				if rm.StartTime == 0 {
 					rm.StartTime = sample.Time.UnixMilli()
 				}
@@ -460,7 +469,7 @@ func (o *Output) flush() {
 		o.updateIngestRate(rm, now)
 		// Update per-query timelines
 		for _, qm := range rm.Queries {
-			o.updateQueryTimeline(qm, rm.StartTime, now)
+			o.updateQueryTimeline(qm, now)
 		}
 		// Mark run ended after inactivity timeout.
 		if rm.EndTime == 0 && rm.LastUpdateTime > 0 && (now-rm.LastUpdateTime) > runEndTimeoutMs {
@@ -475,7 +484,7 @@ func (o *Output) flush() {
 // statistically meaningful sample sizes.
 // When timelineWindow == 0, uses non-overlapping buckets: each point covers only
 // new samples since the last point (original behavior).
-func (o *Output) updateQueryTimeline(qm *QueryMetrics, runStartTime int64, now int64) {
+func (o *Output) updateQueryTimeline(qm *QueryMetrics, now int64) {
 	if len(qm.Latencies) == 0 {
 		return
 	}
@@ -565,11 +574,10 @@ func (o *Output) updateIngestRate(rm *RunMetrics, now int64) {
 		return
 	}
 
-	// First ingest data point - add initial rate
+	// First ingest sample establishes the baseline for subsequent docs/sec calculations.
 	if rm.LastIngestTime == 0 {
 		rm.LastIngestTime = now
 		rm.LastIngestDocs = rm.TotalIngested
-		rm.IngestRate = append(rm.IngestRate, TimeValue{Time: now, Value: float64(rm.TotalIngested)})
 		return
 	}
 
@@ -585,6 +593,19 @@ func (o *Output) updateIngestRate(rm *RunMetrics, now int64) {
 	rm.IngestRate = append(rm.IngestRate, TimeValue{Time: now, Value: rate})
 	rm.LastIngestTime = now
 	rm.LastIngestDocs = rm.TotalIngested
+}
+
+func queryDurationSeconds(qm *QueryMetrics) float64 {
+	if len(qm.Latencies) == 0 {
+		return 0
+	}
+
+	duration := float64(qm.EndTime-qm.StartTime) / 1000
+	minDuration := maxVal(qm.Latencies) / 1000
+	if duration < minDuration {
+		duration = minDuration
+	}
+	return duration
 }
 
 func (o *Output) broadcast() {
@@ -643,28 +664,17 @@ func (o *Output) getSummary() map[string]interface{} {
 
 	runs := make(map[string]interface{})
 	for name, rm := range o.data.Runs {
-		// Calculate run duration (used for QPS calculations)
-		var runDuration float64
-		if rm.StartTime > 0 {
-			if rm.EndTime > 0 {
-				runDuration = float64(rm.EndTime-rm.StartTime) / 1000
-			} else {
-				runDuration = float64(now-rm.StartTime) / 1000
-			}
-		}
-
 		// Calculate ingest rate (docs/sec) based on actual ingest duration
 		var ingestRate float64
-		if rm.TotalIngested > 0 && len(rm.IngestRate) > 0 {
+		if rm.TotalIngested > 0 && rm.FirstIngestTime > 0 {
 			// Use time from first ingest to now/end for accurate rate
-			ingestStart := rm.IngestRate[0].Time
 			var ingestEnd int64
 			if rm.EndTime > 0 {
 				ingestEnd = rm.EndTime
 			} else {
 				ingestEnd = now
 			}
-			ingestDuration := float64(ingestEnd-ingestStart) / 1000
+			ingestDuration := float64(ingestEnd-rm.FirstIngestTime) / 1000
 			if ingestDuration > 0 {
 				ingestRate = float64(rm.TotalIngested) / ingestDuration
 			}
@@ -676,10 +686,10 @@ func (o *Output) getSummary() map[string]interface{} {
 			// Get query pattern for this run/backend+chart+scenario.
 			queryPattern := getQueryPattern(rm.Backend, rm.Chart, qName)
 
-			// Calculate query-specific QPS using run duration
+			// Calculate query-specific QPS using the query's active window.
 			var queryQPS float64
-			if len(qm.Latencies) > 0 && runDuration > 0 {
-				queryQPS = float64(len(qm.Latencies)) / runDuration
+			if queryDuration := queryDurationSeconds(qm); queryDuration > 0 {
+				queryQPS = float64(len(qm.Latencies)) / queryDuration
 			}
 
 			queries[qName] = map[string]interface{}{

--- a/dashboard/output_test.go
+++ b/dashboard/output_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestUpdateIngestRateSkipsInitialPoint(t *testing.T) {
+	o := &Output{}
+	rm := &RunMetrics{TotalIngested: 100}
+
+	o.updateIngestRate(rm, 1000)
+
+	if len(rm.IngestRate) != 0 {
+		t.Fatalf("expected no ingest-rate points on first sample, got %d", len(rm.IngestRate))
+	}
+	if rm.LastIngestTime != 1000 {
+		t.Fatalf("expected first ingest timestamp to be recorded, got %d", rm.LastIngestTime)
+	}
+	if rm.LastIngestDocs != 100 {
+		t.Fatalf("expected first ingest doc count to be recorded, got %d", rm.LastIngestDocs)
+	}
+}
+
+func TestGetSummaryUsesFirstIngestTimeForAverageRate(t *testing.T) {
+	o := &Output{
+		data: &DashboardData{
+			StartTime: time.Unix(0, 0),
+			Runs: map[string]*RunMetrics{
+				"ingest": {
+					Name:            "ingest",
+					Backend:         "paradedb",
+					Queries:         map[string]*QueryMetrics{},
+					TotalIngested:   300,
+					FirstIngestTime: 1000,
+					EndTime:         3000,
+				},
+			},
+		},
+	}
+
+	summary := o.getSummary()
+	runs := summary["runs"].(map[string]interface{})
+	run := runs["ingest"].(map[string]interface{})
+
+	got := run["avgIngestRate"].(float64)
+	if math.Abs(got-150) > 0.001 {
+		t.Fatalf("expected ingest rate of 150 docs/sec, got %.3f", got)
+	}
+}
+
+func TestGetSummaryUsesQueryWindowForQPS(t *testing.T) {
+	latencies := make([]float64, 10)
+	for i := range latencies {
+		latencies[i] = 100
+	}
+
+	o := &Output{
+		data: &DashboardData{
+			StartTime: time.Unix(0, 0),
+			Runs: map[string]*RunMetrics{
+				"search": {
+					Name:      "search",
+					Backend:   "paradedb",
+					StartTime: 1000,
+					EndTime:   21000,
+					Queries: map[string]*QueryMetrics{
+						"search_query": {
+							Name:      "search_query",
+							Latencies: latencies,
+							StartTime: 1000,
+							EndTime:   6000,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	summary := o.getSummary()
+	runs := summary["runs"].(map[string]interface{})
+	run := runs["search"].(map[string]interface{})
+	queries := run["queries"].(map[string]interface{})
+	query := queries["search_query"].(map[string]interface{})
+
+	got := query["qps"].(float64)
+	if math.Abs(got-2.0) > 0.001 {
+		t.Fatalf("expected query qps of 2.0, got %.3f", got)
+	}
+}

--- a/metrics/results.go
+++ b/metrics/results.go
@@ -118,10 +118,36 @@ func EmitScenarioStarted(vu modules.VU, backend string) {
 	emitGaugeMetric(vu, scenarioStarted, backend)
 }
 
+func storeQueryPattern(backend, chart, scenario, query string) {
+	if scenario == "" {
+		return
+	}
+
+	key := queryPatternKey(backend, chart, scenario)
+
+	queryPatternsMu.RLock()
+	_, exists := QueryPatterns[key]
+	queryPatternsMu.RUnlock()
+
+	if exists {
+		return
+	}
+
+	queryPatternsMu.Lock()
+	if _, exists := QueryPatterns[key]; !exists {
+		QueryPatterns[key] = query
+	}
+	queryPatternsMu.Unlock()
+}
+
 // CaptureQueryPattern stores the first query pattern seen for each backend/chart/scenario.
-func CaptureQueryPattern(vu modules.VU, query string) {
+func CaptureQueryPattern(vu modules.VU, backend, query string) {
+	if vu == nil {
+		return
+	}
+
 	state := vu.State()
-	if state == nil {
+	if state == nil || state.Tags == nil {
 		return
 	}
 
@@ -130,27 +156,21 @@ func CaptureQueryPattern(vu modules.VU, query string) {
 	if !ok {
 		return
 	}
-	backend, _ := tags.Tags.Get("backend")
 	chart, _ := tags.Tags.Get("chart")
-	key := queryPatternKey(backend, chart, scenario)
-
-	queryPatternsMu.RLock()
-	_, exists := QueryPatterns[key]
-	queryPatternsMu.RUnlock()
-
-	if !exists {
-		queryPatternsMu.Lock()
-		if _, exists := QueryPatterns[key]; !exists {
-			QueryPatterns[key] = query
-		}
-		queryPatternsMu.Unlock()
+	if backend == "" {
+		backend, _ = tags.Tags.Get("backend")
 	}
+	storeQueryPattern(backend, chart, scenario, query)
 }
 
 // CaptureScenarioInfo stores executor and VU info for each scenario.
 func CaptureScenarioInfo(vu modules.VU) {
+	if vu == nil {
+		return
+	}
+
 	state := vu.State()
-	if state == nil {
+	if state == nil || state.Tags == nil {
 		return
 	}
 

--- a/metrics/results_test.go
+++ b/metrics/results_test.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/lib"
+	k6metrics "go.k6.io/k6/metrics"
+)
+
+type fakeVU struct {
+	ctx   context.Context
+	state *lib.State
+}
+
+func (f fakeVU) Context() context.Context {
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
+}
+
+func (fakeVU) Events() common.Events { return common.Events{} }
+
+func (fakeVU) InitEnv() *common.InitEnvironment { return nil }
+
+func (f fakeVU) State() *lib.State { return f.state }
+
+func (fakeVU) Runtime() *sobek.Runtime { return nil }
+
+func (fakeVU) RegisterCallback() func(func() error) {
+	return func(func() error) {}
+}
+
+func TestCaptureQueryPatternUsesExplicitBackend(t *testing.T) {
+	oldPatterns := QueryPatterns
+	QueryPatterns = make(map[string]string)
+	defer func() {
+		QueryPatterns = oldPatterns
+	}()
+
+	registry := k6metrics.NewRegistry()
+	state := &lib.State{
+		Tags: lib.NewVUStateTags(
+			registry.RootTagSet().
+				With("scenario", "search_scenario").
+				With("chart", "primary"),
+		),
+	}
+
+	CaptureQueryPattern(fakeVU{state: state}, "paradedb", "SELECT 1")
+
+	got := GetQueryPattern("paradedb", "primary", "search_scenario")
+	if got != "SELECT 1" {
+		t.Fatalf("expected captured query for explicit backend, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- pass the backend alias into query-pattern capture so the dashboard can reliably show the actual executed query text
- fix ingest-rate and per-query QPS calculations so summary metrics reflect the real activity window instead of distorted runtime math
- remove hot-path debug logging and add regression tests around dashboard and metrics behavior

## Why
- The dashboard is supposed to show the actual query patterns executed for each backend, but query capture happened before the backend tag was present on emitted samples. That made the stored query patterns unreliable.
- The ingest chart and summary could report an inflated first ingest-rate point, and per-query QPS was divided by the full backend run duration instead of the time that query was actually active.
- Per-batch and per-sample debug logging adds avoidable noise during benchmark runs and can interfere with reading benchmark output.
- The added tests lock the expected behavior around query capture, ingest-rate baselines, average ingest rate, and query-window QPS so these correctness issues do not regress.

## Testing
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go test ./...
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go vet ./...