### PR TITLE
feat: Tighten loader and backend failure handling

### DIFF
--- a/backends/mongodb/driver.go
+++ b/backends/mongodb/driver.go
@@ -127,15 +127,21 @@ func (d *Driver) Exec(ctx context.Context, statements string) error {
 		}
 
 		// Wait for index to be ready
-		d.waitForSearchIndex(ctx, coll, indexName, 120*time.Second)
+		if err := d.waitForSearchIndex(ctx, coll, indexName, 120*time.Second); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (d *Driver) waitForSearchIndex(ctx context.Context, coll *mongo.Collection, indexName string, timeout time.Duration) {
+func (d *Driver) waitForSearchIndex(ctx context.Context, coll *mongo.Collection, indexName string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		cursor, err := coll.SearchIndexes().List(ctx, options.SearchIndexes().SetName(indexName))
 		if err != nil {
 			time.Sleep(2 * time.Second)
@@ -152,11 +158,13 @@ func (d *Driver) waitForSearchIndex(ctx context.Context, coll *mongo.Collection,
 
 		for _, idx := range indexes {
 			if idx["name"] == indexName && idx["status"] == "READY" {
-				return
+				return nil
 			}
 		}
 		time.Sleep(2 * time.Second)
 	}
+
+	return fmt.Errorf("timed out waiting for search index %q to become READY", indexName)
 }
 
 // Query executes a search aggregation and returns the hit count.

--- a/cmd/loader/main.go
+++ b/cmd/loader/main.go
@@ -186,9 +186,9 @@ func runLoad(datasetDir string, backendName string, batchSize int, workers int) 
 		os.Exit(1)
 	}
 
-	csvPath := findCSV(datasetDir)
-	if csvPath == "" {
-		fmt.Println("Error: no CSV file found in dataset directory")
+	csvPath, err := findCSV(datasetDir)
+	if err != nil {
+		fmt.Printf("Error locating CSV file: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -324,10 +324,10 @@ func loadSchema(datasetDir string) (*backends.Schema, error) {
 	return &schema, nil
 }
 
-func findCSV(datasetDir string) string {
+func findCSV(datasetDir string) (string, error) {
 	entries, err := os.ReadDir(datasetDir)
 	if err != nil {
-		return ""
+		return "", err
 	}
 
 	var csvFiles []string
@@ -340,10 +340,13 @@ func findCSV(datasetDir string) string {
 		}
 	}
 	if len(csvFiles) == 0 {
-		return ""
+		return "", fmt.Errorf("no CSV file found in dataset directory")
 	}
-	sort.Strings(csvFiles)
-	return filepath.Join(datasetDir, csvFiles[0])
+	if len(csvFiles) > 1 {
+		sort.Strings(csvFiles)
+		return "", fmt.Errorf("expected exactly one CSV file, found %d: %s", len(csvFiles), strings.Join(csvFiles, ", "))
+	}
+	return filepath.Join(datasetDir, csvFiles[0]), nil
 }
 
 // ============================================================================
@@ -470,6 +473,10 @@ func runPull(datasetName, sourceURL string, anonymous bool) {
 }
 
 func resolveDownloadPath(destDir, prefix, key string) (string, string, error) {
+	if prefix != "" && key != prefix && !strings.HasPrefix(key, prefix+"/") {
+		return "", "", fmt.Errorf("key %q does not match prefix %q", key, prefix)
+	}
+
 	relPath := strings.TrimPrefix(key, prefix)
 	if prefix == "" && strings.HasPrefix(relPath, "/") {
 		return "", "", fmt.Errorf("absolute path %q is not allowed", relPath)

--- a/cmd/loader/main_test.go
+++ b/cmd/loader/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -108,6 +109,12 @@ func TestResolveDownloadPath(t *testing.T) {
 			key:     "/etc/passwd",
 			wantErr: true,
 		},
+		{
+			name:    "prefix collision",
+			prefix:  "datasets/sample",
+			key:     "datasets/sample2/k6/script.js",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -131,4 +138,35 @@ func TestResolveDownloadPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindCSV(t *testing.T) {
+	t.Run("single csv", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "data.csv"), []byte("id\n1\n"), 0644); err != nil {
+			t.Fatalf("write csv: %v", err)
+		}
+
+		got, err := findCSV(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(dir, "data.csv")
+		if got != want {
+			t.Fatalf("findCSV() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("multiple csv files", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, name := range []string{"a.csv", "b.csv"} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("id\n1\n"), 0644); err != nil {
+				t.Fatalf("write %s: %v", name, err)
+			}
+		}
+
+		if _, err := findCSV(dir); err == nil {
+			t.Fatal("expected error when multiple CSV files are present")
+		}
+	})
 }

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -96,14 +96,16 @@ func (l *Loader) OpenDocuments(filePath string) *DocumentReader {
 
 	// Read all rows
 	var docs []map[string]interface{}
+	rowNum := 1 // Header row
 	for {
 		record, err := csvReader.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			continue
+			return l.throwConfigErrorf("openDocuments: failed to read CSV row %d from %q: %v", rowNum+1, filePath, err)
 		}
+		rowNum++
 
 		doc := make(map[string]interface{}, len(headers))
 		for i, header := range headers {
@@ -244,14 +246,16 @@ func readCSVDocuments(filePath string) ([]map[string]interface{}, error) {
 
 	// Read all rows
 	var docs []map[string]interface{}
+	rowNum := 1 // Header row
 	for {
 		record, err := csvReader.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to read CSV row %d from %q: %w", rowNum+1, filePath, err)
 		}
+		rowNum++
 
 		doc := make(map[string]interface{}, len(headers))
 		for i, header := range headers {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,0 +1,25 @@
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadCSVDocumentsReturnsParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.csv")
+	data := "id,title\n1,ok\n2,\"unterminated\n"
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	_, err := readCSVDocuments(path)
+	if err == nil {
+		t.Fatal("expected parse error for malformed CSV")
+	}
+	if !strings.Contains(err.Error(), "row 3") {
+		t.Fatalf("expected row number in error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- surface MongoDB Atlas Search index readiness failures instead of silently continuing
- reject ambiguous or accidental loader inputs before they produce partial or misleading benchmark data
- fail fast on malformed CSV rows and cover the behavior with regression tests

## Why
- MongoDB setup could report success before Atlas Search was actually ready, which pushes the failure later into benchmark execution and makes setup problems harder to diagnose.
- The loader could accidentally download sibling S3 prefixes or silently choose the first CSV file in a dataset directory, which makes dataset selection fragile and easy to misread.
- Silently skipping malformed CSV rows hides bad input and makes benchmark runs less deterministic because the loaded dataset no longer matches the source file.
- The added tests lock in the failure behavior so these edge cases stay visible instead of degrading into silent partial success again.

## Testing
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go test ./...
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go vet ./...