### PR TITLE
feat: Clarify container and empty-text defaults

### DIFF
--- a/backends.go
+++ b/backends.go
@@ -110,11 +110,7 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 			conn = defaults[backendType]
 		}
 		if container == "" {
-			if alias != backendType {
-				container = alias // default container to alias if alias is set
-			} else {
-				container = defaultContainers[backendType]
-			}
+			container = defaultContainers[backendType]
 		}
 
 		// Check for duplicate alias

--- a/backends/driver.go
+++ b/backends/driver.go
@@ -286,12 +286,15 @@ func convertValue(rawValue, schemaType string) any {
 	// Strip null bytes (invalid in PostgreSQL text)
 	rawValue = strings.ReplaceAll(rawValue, "\x00", "")
 
-	// Handle empty strings as NULL for most types
-	if rawValue == "" {
-		return nil
-	}
-
 	schemaType = strings.ToLower(schemaType)
+	if rawValue == "" {
+		switch schemaType {
+		case "text", "varchar", "char", "character varying", "string":
+			return ""
+		default:
+			return nil
+		}
+	}
 
 	switch schemaType {
 	case "bigint", "int8":

--- a/backends/driver_test.go
+++ b/backends/driver_test.go
@@ -1,0 +1,17 @@
+package backends
+
+import "testing"
+
+func TestConvertValuePreservesEmptyText(t *testing.T) {
+	got := convertValue("", "text")
+	if got != "" {
+		t.Fatalf("expected empty text value to stay empty, got %#v", got)
+	}
+}
+
+func TestConvertValueKeepsEmptyIntegerAsNil(t *testing.T) {
+	got := convertValue("", "integer")
+	if got != nil {
+		t.Fatalf("expected empty integer value to become nil, got %#v", got)
+	}
+}

--- a/backends_test.go
+++ b/backends_test.go
@@ -1,0 +1,54 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	backendpkg "github.com/paradedb/benchmarks/backends"
+	"github.com/paradedb/benchmarks/metrics"
+)
+
+type stubDriver struct{}
+
+func (stubDriver) Close() error { return nil }
+
+func (stubDriver) Exec(context.Context, string) error { return nil }
+
+func (stubDriver) Query(context.Context, string, ...any) (int, error) { return 0, nil }
+
+func (stubDriver) Insert(context.Context, string, []string, [][]any) (int, error) { return 0, nil }
+
+func (stubDriver) CaptureConfig(context.Context, string) {}
+
+func TestNewBackendsUsesBackendDefaultContainerWhenAliasIsSet(t *testing.T) {
+	backendName := "testbackendcfgalias"
+	alias := "custom-alias"
+
+	backendpkg.Register(backendName, backendpkg.BackendConfig{
+		Factory:     func(string) (backendpkg.Driver, error) { return stubDriver{}, nil },
+		FileType:    "sql",
+		DefaultConn: "stub://default",
+		Container:   "default-container",
+	})
+
+	m := &ModuleInstance{}
+	b := m.newBackends(map[string]interface{}{
+		"backends": []interface{}{
+			map[string]interface{}{
+				"type":  backendName,
+				"alias": alias,
+			},
+		},
+	})
+	if b == nil {
+		t.Fatal("expected backends configuration to be created")
+	}
+
+	opts := metrics.GetBackendOptions(alias)
+	if opts == nil {
+		t.Fatal("expected backend options to be registered")
+	}
+	if opts.Container != "default-container" {
+		t.Fatalf("expected default container %q, got %q", "default-container", opts.Container)
+	}
+}


### PR DESCRIPTION
## Summary
- decouple backend aliases from the default Docker container name used for metrics collection
- preserve empty strings for text-like CSV columns instead of coercing them to NULL
- add regression tests for both semantics changes

## Why
- An alias is a naming and display concern, but the old behavior also changed the implied container name. That couples configuration fields that should stay independent and makes metrics collection easy to misconfigure.
- Treating every empty CSV value as NULL changes the meaning of text data during load. Empty text fields should stay empty strings, while non-text empty values can still remain NULL.
- The new tests make those defaults explicit so future cleanup does not reintroduce surprising container or text-conversion behavior.

## Testing
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go test ./...
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go vet ./...