### PR TITLE
chore: Fix runtime cancellation and shared-container dashboard behavior

### DIFF
--- a/backends.go
+++ b/backends.go
@@ -50,6 +50,7 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 		clients: make(map[string]*backends.K6Client),
 	}
 	var enabledContainers []string
+	seenContainers := make(map[string]struct{})
 	ctx := context.Background()
 
 	datasetPath := parseDatasetPath(config, m.vu)
@@ -134,7 +135,12 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 
 		client := backends.NewK6Client(m.vu, driver, alias)
 		b.clients[alias] = client
-		enabledContainers = append(enabledContainers, container)
+		if container != "" {
+			if _, seen := seenContainers[container]; !seen {
+				enabledContainers = append(enabledContainers, container)
+				seenContainers[container] = struct{}{}
+			}
+		}
 
 		driver.CaptureConfig(ctx, alias)
 		metrics.CapturePrePostScripts(alias, backendType, datasetPath, backendCfg.FileType)

--- a/backends/driver.go
+++ b/backends/driver.go
@@ -169,6 +169,19 @@ func NewK6Client(vu modules.VU, driver Driver, backend string) *K6Client {
 	return &K6Client{driver: driver, vu: vu, backend: backend, timeout: 0}
 }
 
+func (c *K6Client) requestContext() (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	if c.vu != nil {
+		if vuCtx := c.vu.Context(); vuCtx != nil {
+			ctx = vuCtx
+		}
+	}
+	if c.timeout > 0 {
+		return context.WithTimeout(ctx, c.timeout)
+	}
+	return ctx, func() {}
+}
+
 // SetTimeout sets the query timeout duration.
 // Use 0 to disable timeout (default).
 func (c *K6Client) SetTimeout(seconds int) {
@@ -189,12 +202,8 @@ func (c *K6Client) emitInitMetrics() {
 func (c *K6Client) Search(query string, args ...any) map[string]interface{} {
 	c.emitInitMetrics()
 
-	ctx := context.Background()
-	var cancel context.CancelFunc
-	if c.timeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, c.timeout)
-		defer cancel()
-	}
+	ctx, cancel := c.requestContext()
+	defer cancel()
 
 	// Capture query pattern - for ES/OS style queries (index, queryObj), serialize the query object
 	queryPattern := strings.TrimSpace(query)
@@ -250,7 +259,8 @@ func (c *K6Client) InsertBatch(table string, docs []map[string]interface{}) map[
 		rows[i] = row
 	}
 
-	ctx := context.Background()
+	ctx, cancel := c.requestContext()
+	defer cancel()
 	start := time.Now()
 	count, err := c.driver.Insert(ctx, table, cols, rows)
 	latencyMs := float64(time.Since(start).Microseconds()) / 1000.0

--- a/backends/k6client_test.go
+++ b/backends/k6client_test.go
@@ -1,0 +1,98 @@
+package backends
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/lib"
+)
+
+type clientTestVU struct {
+	ctx context.Context
+}
+
+func (f clientTestVU) Context() context.Context {
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
+}
+
+func (clientTestVU) Events() common.Events { return common.Events{} }
+
+func (clientTestVU) InitEnv() *common.InitEnvironment { return nil }
+
+func (clientTestVU) State() *lib.State { return nil }
+
+func (clientTestVU) Runtime() *sobek.Runtime { return nil }
+
+func (clientTestVU) RegisterCallback() func(func() error) {
+	return func(func() error) {}
+}
+
+type blockingDriver struct{}
+
+func (blockingDriver) Close() error { return nil }
+
+func (blockingDriver) Exec(context.Context, string) error { return nil }
+
+func (blockingDriver) CaptureConfig(context.Context, string) {}
+
+func (blockingDriver) Query(ctx context.Context, _ string, _ ...any) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-time.After(200 * time.Millisecond):
+		return 1, nil
+	}
+}
+
+func (blockingDriver) Insert(ctx context.Context, _ string, _ []string, _ [][]any) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-time.After(200 * time.Millisecond):
+		return 1, nil
+	}
+}
+
+func TestSearchUsesVUContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := NewK6Client(clientTestVU{ctx: ctx}, blockingDriver{}, "paradedb")
+
+	start := time.Now()
+	result := client.Search("SELECT 1")
+	elapsed := time.Since(start)
+
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("expected canceled VU context to stop search quickly, took %s", elapsed)
+	}
+	if result["error"] == nil {
+		t.Fatal("expected canceled search to return an error")
+	}
+}
+
+func TestInsertBatchUsesVUContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := NewK6Client(clientTestVU{ctx: ctx}, blockingDriver{}, "paradedb")
+
+	start := time.Now()
+	result := client.InsertBatch("documents", []map[string]interface{}{
+		{"id": 1},
+	})
+	elapsed := time.Since(start)
+
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("expected canceled VU context to stop insert quickly, took %s", elapsed)
+	}
+	if result["error"] == nil {
+		t.Fatal("expected canceled insert to return an error")
+	}
+}

--- a/backends_test.go
+++ b/backends_test.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	backendpkg "github.com/paradedb/benchmarks/backends"
@@ -50,5 +51,35 @@ func TestNewBackendsUsesBackendDefaultContainerWhenAliasIsSet(t *testing.T) {
 	}
 	if opts.Container != "default-container" {
 		t.Fatalf("expected default container %q, got %q", "default-container", opts.Container)
+	}
+}
+
+func TestNewBackendsDeduplicatesContainerMetricsCollection(t *testing.T) {
+	backendA := "testbackendcontainera"
+	backendB := "testbackendcontainerb"
+
+	for _, name := range []string{backendA, backendB} {
+		backendpkg.Register(name, backendpkg.BackendConfig{
+			Factory:     func(string) (backendpkg.Driver, error) { return stubDriver{}, nil },
+			FileType:    "sql",
+			DefaultConn: "stub://default",
+			Container:   "shared-container",
+		})
+	}
+
+	m := &ModuleInstance{}
+	b := m.newBackends(map[string]interface{}{
+		"backends": []interface{}{backendA, backendB},
+	})
+	if b == nil || b.Metrics == nil {
+		t.Fatal("expected metrics collector to be created")
+	}
+
+	containers := reflect.ValueOf(b.Metrics).Elem().FieldByName("containers")
+	if containers.Len() != 1 {
+		t.Fatalf("expected one deduplicated container, got %d", containers.Len())
+	}
+	if got := containers.Index(0).String(); got != "shared-container" {
+		t.Fatalf("expected shared container name to be preserved, got %q", got)
 	}
 }

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -55,8 +55,10 @@ type ContainerMetrics struct {
 	Backend string      `json:"backend"` // Associated backend name
 	Alias   string      `json:"alias"`   // User-defined alias for display
 	Color   string      `json:"color"`
+	Start   int64       `json:"startTime"`
 	CPU     []TimeValue `json:"cpu"`
 	Memory  []TimeValue `json:"memory"`
+	Shared  bool        `json:"-"`
 }
 
 // RunMetrics holds metrics for a single run/phase.
@@ -148,6 +150,74 @@ func (o *Output) getOrCreateRun(runName, backend string, tags map[string]string)
 	}
 	o.data.Runs[runName] = rm
 	return rm
+}
+
+func recordRunActivity(rm *RunMetrics, sampleTime, now int64) {
+	if rm.StartTime == 0 {
+		rm.StartTime = sampleTime
+	}
+	if rm.EndTime > 0 && sampleTime >= rm.EndTime {
+		rm.EndTime = 0
+	}
+	rm.LastUpdateTime = now
+}
+
+func registerContainer(
+	containers map[string]*ContainerMetrics,
+	container, backend string,
+	opts *metrics.BackendOptions,
+	startTime int64,
+) {
+	if container == "" {
+		return
+	}
+
+	alias := ""
+	color := ""
+	if opts != nil {
+		alias = opts.Alias
+		color = opts.Color
+	}
+
+	cm := containers[container]
+	if cm == nil {
+		containers[container] = &ContainerMetrics{
+			Name:    container,
+			Backend: backend,
+			Alias:   alias,
+			Color:   color,
+			Start:   startTime,
+		}
+		return
+	}
+
+	if startTime > 0 && (cm.Start == 0 || startTime < cm.Start) {
+		cm.Start = startTime
+	}
+	if cm.Shared {
+		return
+	}
+
+	conflicts := (backend != "" && cm.Backend != "" && cm.Backend != backend) ||
+		(alias != "" && cm.Alias != "" && cm.Alias != alias) ||
+		(color != "" && cm.Color != "" && cm.Color != color)
+	if conflicts {
+		cm.Shared = true
+		cm.Backend = ""
+		cm.Alias = ""
+		cm.Color = ""
+		return
+	}
+
+	if cm.Backend == "" {
+		cm.Backend = backend
+	}
+	if cm.Alias == "" {
+		cm.Alias = alias
+	}
+	if cm.Color == "" {
+		cm.Color = color
+	}
 }
 
 // New creates a new dashboard output.
@@ -285,19 +355,7 @@ func (o *Output) flush() {
 				// Register container for metrics
 				opts := metrics.GetBackendOptions(backend)
 				if opts != nil && opts.Container != "" {
-					if o.data.Containers[opts.Container] == nil {
-						o.data.Containers[opts.Container] = &ContainerMetrics{
-							Name:    opts.Container,
-							Backend: backend,
-							Alias:   opts.Alias,
-							Color:   opts.Color,
-						}
-					} else {
-						// Update backend/color/alias info if container already exists
-						o.data.Containers[opts.Container].Backend = backend
-						o.data.Containers[opts.Container].Alias = opts.Alias
-						o.data.Containers[opts.Container].Color = opts.Color
-					}
+					registerContainer(o.data.Containers, opts.Container, backend, opts, sample.Time.UnixMilli())
 				}
 
 			case name == "scenario_started":
@@ -310,9 +368,7 @@ func (o *Output) flush() {
 
 				runName := getRunName(backend, tags)
 				rm := o.getOrCreateRun(runName, backend, tags)
-				if rm.StartTime == 0 {
-					rm.StartTime = sample.Time.UnixMilli()
-				}
+				recordRunActivity(rm, sample.Time.UnixMilli(), now)
 
 			case name == "search_duration":
 				backend := tags["backend"]
@@ -329,10 +385,7 @@ func (o *Output) flush() {
 				runName := getRunName(backend, tags)
 				rm := o.getOrCreateRun(runName, backend, tags)
 				rm.Latencies = append(rm.Latencies, value)
-				if rm.StartTime == 0 {
-					rm.StartTime = sample.Time.UnixMilli()
-				}
-				rm.LastUpdateTime = now
+				recordRunActivity(rm, sample.Time.UnixMilli(), now)
 
 				// Track per-query metrics
 				queryName := tags["query"]
@@ -396,7 +449,9 @@ func (o *Output) flush() {
 				}
 				// Create container entry if it doesn't exist
 				if o.data.Containers[container] == nil {
-					o.data.Containers[container] = &ContainerMetrics{Name: container}
+					o.data.Containers[container] = &ContainerMetrics{Name: container, Start: sample.Time.UnixMilli()}
+				} else if o.data.Containers[container].Start == 0 {
+					o.data.Containers[container].Start = sample.Time.UnixMilli()
 				}
 				o.data.Containers[container].CPU = append(o.data.Containers[container].CPU, TimeValue{Time: sample.Time.UnixMilli(), Value: value})
 
@@ -407,7 +462,9 @@ func (o *Output) flush() {
 				}
 				// Create container entry if it doesn't exist
 				if o.data.Containers[container] == nil {
-					o.data.Containers[container] = &ContainerMetrics{Name: container}
+					o.data.Containers[container] = &ContainerMetrics{Name: container, Start: sample.Time.UnixMilli()}
+				} else if o.data.Containers[container].Start == 0 {
+					o.data.Containers[container].Start = sample.Time.UnixMilli()
 				}
 				o.data.Containers[container].Memory = append(o.data.Containers[container].Memory, TimeValue{Time: sample.Time.UnixMilli(), Value: value})
 
@@ -429,10 +486,7 @@ func (o *Output) flush() {
 				if rm.FirstIngestTime == 0 {
 					rm.FirstIngestTime = sample.Time.UnixMilli()
 				}
-				if rm.StartTime == 0 {
-					rm.StartTime = sample.Time.UnixMilli()
-				}
-				rm.LastUpdateTime = now
+				recordRunActivity(rm, sample.Time.UnixMilli(), now)
 			}
 		}
 	}
@@ -663,12 +717,13 @@ func (o *Output) getSummary() map[string]interface{} {
 	containers := make(map[string]interface{})
 	for name, cm := range o.data.Containers {
 		containers[name] = map[string]interface{}{
-			"name":    cm.Name,
-			"backend": cm.Backend,
-			"alias":   cm.Alias,
-			"color":   cm.Color,
-			"cpu":     cm.CPU,
-			"memory":  cm.Memory,
+			"name":      cm.Name,
+			"backend":   cm.Backend,
+			"alias":     cm.Alias,
+			"color":     cm.Color,
+			"startTime": cm.Start,
+			"cpu":       cm.CPU,
+			"memory":    cm.Memory,
 		}
 	}
 

--- a/dashboard/output_test.go
+++ b/dashboard/output_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/paradedb/benchmarks/metrics"
 )
 
 func TestUpdateIngestRateSkipsInitialPoint(t *testing.T) {
@@ -87,5 +89,48 @@ func TestGetSummaryUsesQueryWindowForQPS(t *testing.T) {
 	got := query["qps"].(float64)
 	if math.Abs(got-2.0) > 0.001 {
 		t.Fatalf("expected query qps of 2.0, got %.3f", got)
+	}
+}
+
+func TestRecordRunActivityReopensEndedRun(t *testing.T) {
+	rm := &RunMetrics{
+		StartTime: 1000,
+		EndTime:   2000,
+	}
+
+	recordRunActivity(rm, 3000, 3500)
+
+	if rm.EndTime != 0 {
+		t.Fatalf("expected run to reopen on new activity, got end time %d", rm.EndTime)
+	}
+	if rm.LastUpdateTime != 3500 {
+		t.Fatalf("expected last update time to be recorded, got %d", rm.LastUpdateTime)
+	}
+}
+
+func TestRegisterContainerClearsIdentityForSharedContainer(t *testing.T) {
+	containers := map[string]*ContainerMetrics{}
+
+	registerContainer(containers, "shared", "paradedb", &metrics.BackendOptions{
+		Alias: "paradedb-a",
+		Color: "#111111",
+	}, 1000)
+	registerContainer(containers, "shared", "elasticsearch", &metrics.BackendOptions{
+		Alias: "es-b",
+		Color: "#222222",
+	}, 2000)
+
+	cm := containers["shared"]
+	if cm == nil {
+		t.Fatal("expected container metrics entry to be created")
+	}
+	if !cm.Shared {
+		t.Fatal("expected shared container to be marked ambiguous")
+	}
+	if cm.Backend != "" || cm.Alias != "" || cm.Color != "" {
+		t.Fatalf("expected shared container identity to be cleared, got backend=%q alias=%q color=%q", cm.Backend, cm.Alias, cm.Color)
+	}
+	if cm.Start != 1000 {
+		t.Fatalf("expected earliest container start time to be preserved, got %d", cm.Start)
 	}
 }

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -736,6 +736,10 @@
       let containerColorIndex = 0;
 
       function getContainerColor(name, container) {
+        const hasIdentityMetadata =
+          Boolean(container?.alias) ||
+          Boolean(container?.backend) ||
+          Boolean(container?.color);
         // Check for custom color first
         if (container?.color) {
           const customColor = sanitizeColor(container.color);
@@ -745,7 +749,7 @@
           }
         }
         // Try to match with a run's color for consistency across panels
-        if (lastData?.runs) {
+        if (lastData?.runs && hasIdentityMetadata) {
           for (const [runName, runData] of Object.entries(lastData.runs)) {
             if (runData.backend === container?.backend || runData.container === name) {
               return getRunColor(runName, runData);
@@ -1906,7 +1910,7 @@
             return byContainer[0];
           }
           if (byContainer.length > 1) {
-            return byContainer.sort((a, b) => (a.startTime || 0) - (b.startTime || 0))[0];
+            return null;
           }
 
           // Fallback to backend only when unambiguous.
@@ -1921,7 +1925,7 @@
         const activeContainerNames = Object.keys(containers).filter(name => {
           const container = containers[name];
           const matchingRun = getContainerRun(name, container);
-          return matchingRun?.startTime > 0;
+          return (container.startTime || 0) > 0 || matchingRun?.startTime > 0;
         }).sort();
 
         if (activeContainerNames.length > 0) {
@@ -1930,7 +1934,7 @@
           // Find start time for each container based on its associated run
           const getContainerBaseline = (container) => {
             const matchingRun = getContainerRun(container.name, container);
-            return matchingRun?.startTime || data.startTime || Date.now();
+            return container.startTime || matchingRun?.startTime || data.startTime || Date.now();
           };
 
           const cpuDatasets = activeContainerNames.map((name) => {


### PR DESCRIPTION
## Summary
- reuse the VU context for backend search and insert calls instead of always running on background contexts
- deduplicate shared container polling and make container metrics neutral when multiple aliases share one Docker container
- reopen runs on fresh activity after inactivity timeouts and cover the behavior with regression tests

## Why
- canceled k6 scenarios should stop backend work promptly rather than leaving search or ingest calls running until the backend returns on its own
- when multiple aliases point at the same container, the dashboard should not poll that container multiple times or attribute it to whichever alias initialized last
- a run that becomes active again after a gap should not keep a stale end time because that freezes later dashboard summary math against the old window

## Testing
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go test ./...
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go vet ./...