### PR TITLE
chore: Tighten loader and MongoDB data semantics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ datasets/<name>/
 │   ├── pre.json          # Index mapping
 │   └── post.json         # Refresh, force merge
 └── k6/
-    └── benchmark.js      # k6 test script
+    └── *.js              # k6 test scripts
 ```
 
 SQL backends use `.sql` files, HTTP backends (Elasticsearch, OpenSearch, MongoDB) use `.json`.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Then open http://localhost:5665/static/ in your browser.
 
 ```bash
 # Export dashboard data during run
-DASHBOARD_EXPORT=true ./k6 run --out dashboard benchmark.js
+DASHBOARD_EXPORT=true ./k6 run --out dashboard datasets/sample/k6/simple.js
 
 # View saved data later (use generated dashboard_<timestamp>.json file)
 ./bin/dashboard-viewer ./dashboard_2026-02-28_12-00-00.json
@@ -345,7 +345,7 @@ export function ingestTest() {
 }
 ```
 
-The `nextBatchNewIds()` method returns documents with new UUID strings in the `id` field, cycling through the source file. This allows continuous ingestion without ID conflicts.
+The `nextBatchNewIds()` method returns documents with new UUID strings in the `id` field, cycling through the source file. Use it only when your dataset has an `id` column that accepts UUID-style string values.
 
 ## Data Loader
 

--- a/backends/driver.go
+++ b/backends/driver.go
@@ -290,7 +290,7 @@ func (c *K6Client) Close() {
 }
 
 // convertValue converts a raw CSV string value to the appropriate Go type based on schema type.
-func convertValue(rawValue, schemaType string) any {
+func convertValue(rawValue, schemaType string) (any, error) {
 	// Strip null bytes (invalid in PostgreSQL text)
 	rawValue = strings.ReplaceAll(rawValue, "\x00", "")
 
@@ -298,9 +298,9 @@ func convertValue(rawValue, schemaType string) any {
 	if rawValue == "" {
 		switch schemaType {
 		case "text", "varchar", "char", "character varying", "string":
-			return ""
+			return "", nil
 		default:
-			return nil
+			return nil, nil
 		}
 	}
 
@@ -308,40 +308,47 @@ func convertValue(rawValue, schemaType string) any {
 	case "bigint", "int8":
 		v, err := strconv.ParseInt(rawValue, 10, 64)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("invalid bigint %q: %w", rawValue, err)
 		}
-		return v
+		return v, nil
 
 	case "integer", "int", "int4":
 		v, err := strconv.ParseInt(rawValue, 10, 32)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("invalid integer %q: %w", rawValue, err)
 		}
-		return int32(v)
+		return int32(v), nil
 
 	case "boolean", "bool":
-		return rawValue == "true" || rawValue == "t" || rawValue == "1"
+		switch strings.ToLower(rawValue) {
+		case "true", "t", "1":
+			return true, nil
+		case "false", "f", "0":
+			return false, nil
+		default:
+			return nil, fmt.Errorf("invalid boolean %q", rawValue)
+		}
 
 	case "bigint[]", "int8[]":
 		var arr []int64
 		if err := json.Unmarshal([]byte(rawValue), &arr); err != nil {
-			return []int64{} // Return empty array on parse error
+			return nil, fmt.Errorf("invalid bigint array %q: %w", rawValue, err)
 		}
-		return arr
+		return arr, nil
 
 	case "integer[]", "int[]", "int4[]":
 		var arr []int32
 		if err := json.Unmarshal([]byte(rawValue), &arr); err != nil {
-			return []int32{}
+			return nil, fmt.Errorf("invalid integer array %q: %w", rawValue, err)
 		}
-		return arr
+		return arr, nil
 
 	case "text[]", "varchar[]":
 		var arr []string
 		if err := json.Unmarshal([]byte(rawValue), &arr); err != nil {
-			return []string{}
+			return nil, fmt.Errorf("invalid text array %q: %w", rawValue, err)
 		}
-		return arr
+		return arr, nil
 
 	case "timestamp", "timestamptz":
 		// Try common timestamp formats
@@ -353,23 +360,53 @@ func convertValue(rawValue, schemaType string) any {
 		}
 		for _, format := range formats {
 			if t, err := time.Parse(format, rawValue); err == nil {
-				return t
+				return t, nil
 			}
 		}
-		return nil // Unparseable timestamp
+		return nil, fmt.Errorf("invalid timestamp %q", rawValue)
 
 	case "jsonb", "json":
-		// Parse JSON into a map for ES/OS compatibility
-		var obj map[string]interface{}
+		var obj interface{}
 		if err := json.Unmarshal([]byte(rawValue), &obj); err != nil {
-			return rawValue // Fall back to string if not valid JSON
+			return nil, fmt.Errorf("invalid json %q: %w", rawValue, err)
 		}
-		return obj
+		return obj, nil
 
 	default:
 		// text, varchar, etc - return as-is
-		return rawValue
+		return rawValue, nil
 	}
+}
+
+func schemaColumnsInOrder(schema *Schema, headers []string) ([]string, error) {
+	if schema == nil || len(schema.Columns) == 0 {
+		return nil, fmt.Errorf("schema has no columns")
+	}
+
+	seen := make(map[string]struct{}, len(headers))
+	cols := make([]string, 0, len(headers))
+	for _, header := range headers {
+		if _, ok := schema.Columns[header]; ok {
+			cols = append(cols, header)
+			seen[header] = struct{}{}
+		}
+	}
+
+	missing := make([]string, 0)
+	for col := range schema.Columns {
+		if _, ok := seen[col]; !ok {
+			missing = append(missing, col)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("schema columns missing from CSV: %s", strings.Join(missing, ", "))
+	}
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("no schema columns matched CSV headers")
+	}
+
+	return cols, nil
 }
 
 // CLILoader wraps a Driver for CLI bulk loading.
@@ -458,15 +495,9 @@ func (l *CLILoader) Load(ctx context.Context, schema *Schema, csvPath string, ba
 		headerIdx[h] = i
 	}
 
-	// Determine which columns to use from schema
-	var cols []string
-	for col := range schema.Columns {
-		if _, ok := headerIdx[col]; ok {
-			cols = append(cols, col)
-		}
-	}
-	if len(cols) == 0 {
-		return 0, fmt.Errorf("no schema columns matched CSV headers")
+	cols, err := schemaColumnsInOrder(schema, headers)
+	if err != nil {
+		return 0, err
 	}
 
 	target := schema.Table
@@ -545,15 +576,18 @@ func (l *CLILoader) Load(ctx context.Context, schema *Schema, csvPath string, ba
 	}
 
 	batch := make([][]any, 0, batchSize)
+	rowNum := 1 // Header row
+rowLoop:
 	for {
 		record, err := reader.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			setErr(err)
+			setErr(fmt.Errorf("failed to read CSV row %d from %q: %w", rowNum+1, csvPath, err))
 			break
 		}
+		rowNum++
 
 		row := make([]any, len(cols))
 		for i, col := range cols {
@@ -562,7 +596,12 @@ func (l *CLILoader) Load(ctx context.Context, schema *Schema, csvPath string, ba
 				row[i] = nil
 				continue
 			}
-			row[i] = convertValue(record[idx], schema.Columns[col])
+			value, err := convertValue(record[idx], schema.Columns[col])
+			if err != nil {
+				setErr(fmt.Errorf("row %d column %q: %w", rowNum, col, err))
+				break rowLoop
+			}
+			row[i] = value
 		}
 		batch = append(batch, row)
 
@@ -643,8 +682,14 @@ func (l *CLILoader) Drop(ctx context.Context, schema *Schema) error {
 			}
 			return l.driver.Exec(ctx, string(data))
 		case "mongodb":
+			database := "benchmark"
+			if provider, ok := l.driver.(interface{ DatabaseName() string }); ok {
+				if name := provider.DatabaseName(); name != "" {
+					database = name
+				}
+			}
 			cfg := map[string]interface{}{
-				"database":   "benchmark",
+				"database":   database,
 				"collection": target,
 				"drop":       true,
 			}

--- a/backends/driver_test.go
+++ b/backends/driver_test.go
@@ -1,17 +1,113 @@
 package backends
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestConvertValuePreservesEmptyText(t *testing.T) {
-	got := convertValue("", "text")
+	got, err := convertValue("", "text")
+	if err != nil {
+		t.Fatalf("expected empty text conversion to succeed, got %v", err)
+	}
 	if got != "" {
 		t.Fatalf("expected empty text value to stay empty, got %#v", got)
 	}
 }
 
 func TestConvertValueKeepsEmptyIntegerAsNil(t *testing.T) {
-	got := convertValue("", "integer")
+	got, err := convertValue("", "integer")
+	if err != nil {
+		t.Fatalf("expected empty integer conversion to succeed, got %v", err)
+	}
 	if got != nil {
 		t.Fatalf("expected empty integer value to become nil, got %#v", got)
+	}
+}
+
+func TestConvertValueRejectsInvalidJSONArray(t *testing.T) {
+	_, err := convertValue("not-json", "text[]")
+	if err == nil {
+		t.Fatal("expected invalid array JSON to return an error")
+	}
+}
+
+type recordingDriver struct {
+	inserted int
+}
+
+func (d *recordingDriver) Close() error { return nil }
+
+func (d *recordingDriver) Exec(context.Context, string) error { return nil }
+
+func (d *recordingDriver) Query(context.Context, string, ...any) (int, error) { return 0, nil }
+
+func (d *recordingDriver) Insert(_ context.Context, _ string, _ []string, rows [][]any) (int, error) {
+	d.inserted += len(rows)
+	return len(rows), nil
+}
+
+func (d *recordingDriver) CaptureConfig(context.Context, string) {}
+
+func TestCLILoaderLoadFailsWhenSchemaColumnsAreMissingFromCSV(t *testing.T) {
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(csvPath, []byte("id,title\n1,hello\n"), 0644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	driver := &recordingDriver{}
+	loader := NewCLILoader("test", "sql", "stub://default", func(string) (Driver, error) {
+		return driver, nil
+	})
+
+	_, err := loader.Load(context.Background(), &Schema{
+		Table: "documents",
+		Columns: map[string]string{
+			"id":      "text",
+			"title":   "text",
+			"content": "text",
+		},
+	}, csvPath, 100, 1)
+	if err == nil {
+		t.Fatal("expected schema drift to return an error")
+	}
+	if !strings.Contains(err.Error(), "schema columns missing from CSV: content") {
+		t.Fatalf("expected missing-column error, got %v", err)
+	}
+	if driver.inserted != 0 {
+		t.Fatalf("expected no rows to be inserted, got %d", driver.inserted)
+	}
+}
+
+func TestCLILoaderLoadFailsOnInvalidTypedValue(t *testing.T) {
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(csvPath, []byte("numbers\nnot-json\n"), 0644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	driver := &recordingDriver{}
+	loader := NewCLILoader("test", "sql", "stub://default", func(string) (Driver, error) {
+		return driver, nil
+	})
+
+	_, err := loader.Load(context.Background(), &Schema{
+		Table: "documents",
+		Columns: map[string]string{
+			"numbers": "integer[]",
+		},
+	}, csvPath, 100, 1)
+	if err == nil {
+		t.Fatal("expected typed conversion error")
+	}
+	if !strings.Contains(err.Error(), `row 2 column "numbers"`) {
+		t.Fatalf("expected row/column context in error, got %v", err)
+	}
+	if driver.inserted != 0 {
+		t.Fatalf("expected no rows to be inserted, got %d", driver.inserted)
 	}
 }

--- a/backends/mongodb/driver.go
+++ b/backends/mongodb/driver.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/paradedb/benchmarks/backends"
@@ -13,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	mongoconnstring "go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
 func init() {
@@ -27,8 +29,9 @@ func init() {
 
 // Driver implements the backends.Driver interface for MongoDB.
 type Driver struct {
-	client   *mongo.Client
-	database string
+	client     *mongo.Client
+	database   string
+	databaseMu sync.RWMutex
 }
 
 func isLocalMongoURI(connString string) bool {
@@ -67,7 +70,7 @@ func New(connString string) (backends.Driver, error) {
 		return nil, err
 	}
 
-	return &Driver{client: client, database: "benchmark"}, nil
+	return &Driver{client: client, database: databaseFromConnString(connString)}, nil
 }
 
 // Close disconnects the client.
@@ -78,6 +81,30 @@ func (d *Driver) Close() error {
 	return nil
 }
 
+func databaseFromConnString(connString string) string {
+	cs, err := mongoconnstring.ParseAndValidate(connString)
+	if err == nil && cs.Database != "" {
+		return cs.Database
+	}
+	return "benchmark"
+}
+
+func (d *Driver) getDatabase() string {
+	d.databaseMu.RLock()
+	defer d.databaseMu.RUnlock()
+	return d.database
+}
+
+func (d *Driver) setDatabase(database string) {
+	d.databaseMu.Lock()
+	defer d.databaseMu.Unlock()
+	d.database = database
+}
+
+func (d *Driver) DatabaseName() string {
+	return d.getDatabase()
+}
+
 // Exec executes JSON configuration (drop collection, create search index, etc).
 func (d *Driver) Exec(ctx context.Context, statements string) error {
 	var config map[string]interface{}
@@ -85,9 +112,10 @@ func (d *Driver) Exec(ctx context.Context, statements string) error {
 		return err
 	}
 
-	database := d.database
+	database := d.getDatabase()
 	if db, ok := config["database"].(string); ok {
 		database = db
+		d.setDatabase(database)
 	}
 
 	collection := "documents"
@@ -185,7 +213,7 @@ func (d *Driver) Query(ctx context.Context, query string, args ...any) (int, err
 		{{Key: "$search", Value: searchStage}},
 	}
 
-	cursor, err := d.client.Database(d.database).Collection(collection).Aggregate(ctx, pipeline)
+	cursor, err := d.client.Database(d.getDatabase()).Collection(collection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return 0, err
 	}
@@ -213,7 +241,7 @@ func (d *Driver) Insert(ctx context.Context, collection string, cols []string, r
 		docs[i] = doc
 	}
 
-	result, err := d.client.Database(d.database).Collection(collection).InsertMany(ctx, docs)
+	result, err := d.client.Database(d.getDatabase()).Collection(collection).InsertMany(ctx, docs)
 	if err != nil {
 		return 0, err
 	}

--- a/backends/mongodb/driver_test.go
+++ b/backends/mongodb/driver_test.go
@@ -1,0 +1,24 @@
+package mongodb
+
+import "testing"
+
+func TestDatabaseFromConnStringUsesExplicitDatabase(t *testing.T) {
+	got := databaseFromConnString("mongodb://localhost:27017/customdb")
+	if got != "customdb" {
+		t.Fatalf("expected database from connection string, got %q", got)
+	}
+}
+
+func TestDatabaseFromConnStringDecodesEscapedDatabase(t *testing.T) {
+	got := databaseFromConnString("mongodb://localhost:27017/custom%2Ddb")
+	if got != "custom-db" {
+		t.Fatalf("expected escaped database name to be decoded, got %q", got)
+	}
+}
+
+func TestDatabaseFromConnStringFallsBackToBenchmark(t *testing.T) {
+	got := databaseFromConnString("mongodb://localhost:27017")
+	if got != "benchmark" {
+		t.Fatalf("expected default benchmark database, got %q", got)
+	}
+}

--- a/datasets/sample/k6/ingest_with_queries_new.js
+++ b/datasets/sample/k6/ingest_with_queries_new.js
@@ -49,7 +49,7 @@ export const options = {
       executor: "constant-vus",
       vus: 5,
       duration: "30s",
-      exec: "pgSimpleQuery",
+      exec: "paradedbSimpleQuery",
     },
     // ParadeDB ingest: 0s - 30s (parallel with query)
     pdb_ingest: {
@@ -142,7 +142,7 @@ export function collectMetrics() {
 }
 
 // ==================== ParadeDB ====================
-export function pgSimpleQuery() {
+export function paradedbSimpleQuery() {
   const term = getTerm();
   backends.get("paradedb").search(
     `

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -149,8 +149,9 @@ func (r *DocumentReader) NextBatch(n int) []map[string]interface{} {
 	return batch
 }
 
-// NextBatchNewIds returns the next n documents with fresh UUIDs.
-// Use this when re-inserting documents that already exist in the database.
+// NextBatchNewIds returns the next n documents with fresh UUIDs in the "id" field.
+// Use this when re-inserting documents that already exist in the database and the
+// dataset stores identifiers in an "id" column that accepts UUID-style strings.
 // Thread-safe via atomic counter.
 func (r *DocumentReader) NextBatchNewIds(n int) []map[string]interface{} {
 	if r.size == 0 || n <= 0 {


### PR DESCRIPTION
## Summary
- make the CLI loader fail on schema or header drift and on malformed typed CSV values
- carry MongoDB database selection from the connection string and setup config through load and drop paths
- clean up the remaining sample and docs drift around export examples, sample naming, and nextBatchNewIds constraints

## Why
- silently loading only the intersecting schema columns or coercing malformed structured values makes benchmark input diverge from the source dataset
- MongoDB setup, load, query, insert, and drop should target the same database consistently instead of partially falling back to a hard-coded benchmark database
- the docs and bundled sample scripts should point at the files and helper behavior that the repository actually ships today

## Testing
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go test ./...
- GOCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gocache GOMODCACHE=/Users/philippemnoel/Downloads/paradedb/benchmarks/.gomodcache go vet ./...