### PR TITLE
chore: Tighten loader behavior and sample docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ make         # Build k6 and loader
 To verify your setup, start the backends and run a benchmark:
 
 ```bash
-docker compose --profile all up -d
-./bin/loader load ./datasets/sample
+docker compose --profile paradedb up -d
+./bin/loader load --backend paradedb ./datasets/sample
 ./k6 run --out dashboard datasets/sample/k6/simple.js
 ```
 
@@ -96,6 +96,12 @@ datasets/<name>/
 ├── paradedb/
 │   ├── pre.sql           # Create tables
 │   └── post.sql          # Create indexes, VACUUM
+├── postgresfts/
+│   ├── pre.sql
+│   └── post.sql
+├── pgtextsearch/
+│   ├── pre.sql
+│   └── post.sql
 ├── elasticsearch/
 │   ├── pre.json          # Index mapping
 │   └── post.json         # Refresh, force merge

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  all      Build everything (default)"
-	@echo "  build    Build k6 and loader"
+	@echo "  build    Build k6, loader, and viewer"
 	@echo "  k6       Build k6 with xk6-search extension"
 	@echo "  loader   Build the loader CLI to bin/"
 	@echo "  viewer   Build the dashboard-viewer CLI to bin/"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker compose --profile all up -d
 ### 2. Build
 
 ```bash
-make        # Builds both k6 and loader
+make        # Builds k6, the loader, and the dashboard viewer
 ```
 
 Or individually:
@@ -46,7 +46,7 @@ make loader # Build the loader CLI
 ### 3. Load test data
 
 ```bash
-./bin/loader load ./datasets/sample
+./bin/loader load --backend paradedb ./datasets/sample
 ```
 
 ### 4. Run a benchmark
@@ -55,7 +55,7 @@ make loader # Build the loader CLI
 ./k6 run --out dashboard datasets/sample/k6/simple.js
 ```
 
-Open http://localhost:5665/static/ to see real-time results.
+The sample script runs for 30 seconds. Open http://localhost:5665/static/ to see real-time results.
 
 ## Writing k6 Scripts
 
@@ -351,6 +351,8 @@ The `nextBatchNewIds()` method returns documents with new UUID strings in the `i
 
 The loader CLI handles bulk data loading with lifecycle scripts.
 
+The `load` and `drop` commands only work for backends that have a matching config directory in the dataset, and `load` expects the corresponding backend service to be running.
+
 ### Commands
 
 ```bash
@@ -380,6 +382,12 @@ datasets/
     ├── paradedb/
     │   ├── pre.sql              # Create tables, indexes
     │   └── post.sql             # VACUUM, ANALYZE
+    ├── postgresfts/
+    │   ├── pre.sql
+    │   └── post.sql
+    ├── pgtextsearch/
+    │   ├── pre.sql
+    │   └── post.sql
     ├── elasticsearch/
     │   ├── pre.json             # Create index with mappings
     │   └── post.json            # Refresh, force merge
@@ -409,7 +417,7 @@ columns:
 
 ### Pre/Post Scripts
 
-Pre and post scripts are defined per dataset in the dataset directory (e.g., `datasets/sample/paradedb/pre.sql`). They run during data loading to set up and optimize each backend.
+Pre and post scripts are defined per dataset in the dataset directory (for example, `datasets/sample/paradedb/pre.sql`). They run during data loading to set up and optimize each backend.
 
 #### SQL Backends (ParadeDB, PostgreSQL, ClickHouse)
 

--- a/cmd/loader/main.go
+++ b/cmd/loader/main.go
@@ -215,8 +215,13 @@ func runLoad(datasetDir string, backendName string, batchSize int, workers int) 
 				}
 			}()
 
-			dir := filepath.Join(datasetDir, loader.Name())
-			if _, err := os.Stat(dir); os.IsNotExist(err) {
+			dir, ok, err := datasetBackendDir(datasetDir, loader.Name())
+			if err != nil {
+				fmt.Printf("FAILED: %v\n", err)
+				overallFailed = true
+				return
+			}
+			if !ok {
 				fmt.Printf("Skipping %s (no config directory)\n", loader.Name())
 				return
 			}
@@ -293,15 +298,41 @@ func runDrop(datasetDir string, backendName string) {
 	}
 
 	ctx := context.Background()
+	overallFailed := false
 
 	for _, b := range loaders {
-		fmt.Printf("Dropping %s... ", b.Name())
-		if err := b.Drop(ctx, schema); err != nil {
-			fmt.Printf("FAILED: %v\n", err)
-		} else {
+		func(loader *backends.CLILoader) {
+			defer func() {
+				if err := loader.Close(); err != nil {
+					fmt.Printf("Warning: failed to close %s: %v\n", loader.Name(), err)
+				}
+			}()
+
+			_, ok, err := datasetBackendDir(datasetDir, loader.Name())
+			if err != nil {
+				fmt.Printf("Dropping %s... FAILED: %v\n", loader.Name(), err)
+				overallFailed = true
+				return
+			}
+			if !ok {
+				fmt.Printf("Skipping %s (no config directory)\n", loader.Name())
+				return
+			}
+
+			fmt.Printf("Dropping %s... ", loader.Name())
+			if err := loader.Drop(ctx, schema); err != nil {
+				fmt.Printf("FAILED: %v\n", err)
+				overallFailed = true
+				return
+			}
 			fmt.Println("OK")
-		}
-		b.Close()
+
+		}(b)
+	}
+
+	if overallFailed {
+		fmt.Println("\nCompleted with errors.")
+		os.Exit(1)
 	}
 }
 
@@ -349,6 +380,21 @@ func findCSV(datasetDir string) (string, error) {
 	return filepath.Join(datasetDir, csvFiles[0]), nil
 }
 
+func datasetBackendDir(datasetDir, backendName string) (string, bool, error) {
+	dir := filepath.Join(datasetDir, backendName)
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dir, false, nil
+		}
+		return "", false, err
+	}
+	if !info.IsDir() {
+		return "", false, fmt.Errorf("%q exists but is not a directory", dir)
+	}
+	return dir, true, nil
+}
+
 // ============================================================================
 // S3 Pull
 // ============================================================================
@@ -372,7 +418,7 @@ func runPull(datasetName, sourceURL string, anonymous bool) {
 	if anonymous {
 		cfg, err = config.LoadDefaultConfig(ctx,
 			config.WithCredentialsProvider(aws.AnonymousCredentials{}),
-			config.WithRegion("us-east-1"),
+			config.WithRegion(anonymousRegion()),
 		)
 	} else {
 		cfg, err = config.LoadDefaultConfig(ctx)
@@ -470,6 +516,13 @@ func runPull(datasetName, sourceURL string, anonymous bool) {
 	if failed > 0 {
 		os.Exit(1)
 	}
+}
+
+func anonymousRegion() string {
+	if region := strings.TrimSpace(os.Getenv("AWS_REGION")); region != "" {
+		return region
+	}
+	return "us-east-1"
 }
 
 func resolveDownloadPath(destDir, prefix, key string) (string, string, error) {

--- a/cmd/loader/main_test.go
+++ b/cmd/loader/main_test.go
@@ -170,3 +170,55 @@ func TestFindCSV(t *testing.T) {
 		}
 	})
 }
+
+func TestDatasetBackendDir(t *testing.T) {
+	t.Run("existing directory", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(dir, "paradedb"), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		got, ok, err := datasetBackendDir(dir, "paradedb")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected backend config directory to exist")
+		}
+		want := filepath.Join(dir, "paradedb")
+		if got != want {
+			t.Fatalf("datasetBackendDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing directory", func(t *testing.T) {
+		dir := t.TempDir()
+		got, ok, err := datasetBackendDir(dir, "paradedb")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatal("expected missing backend config directory to return false")
+		}
+		want := filepath.Join(dir, "paradedb")
+		if got != want {
+			t.Fatalf("datasetBackendDir() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestAnonymousRegion(t *testing.T) {
+	t.Run("defaults to us-east-1", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "")
+		if got := anonymousRegion(); got != "us-east-1" {
+			t.Fatalf("anonymousRegion() = %q, want %q", got, "us-east-1")
+		}
+	})
+
+	t.Run("uses aws region env var", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "eu-west-1")
+		if got := anonymousRegion(); got != "eu-west-1" {
+			t.Fatalf("anonymousRegion() = %q, want %q", got, "eu-west-1")
+		}
+	})
+}

--- a/datasets/sample/k6/simple.js
+++ b/datasets/sample/k6/simple.js
@@ -24,7 +24,7 @@ export const options = {
     metrics_collector: {
       executor: "constant-vus",
       vus: 1,
-      duration: "500s",
+      duration: "35s",
       exec: "collectMetrics",
     },
 
@@ -32,7 +32,7 @@ export const options = {
     paradedb_simple: {
       executor: "constant-vus",
       vus: 5,
-      duration: "500s",
+      duration: "30s",
       exec: "paradedbSimpleQuery",
     },
   },

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -199,19 +201,45 @@ func parseConfig(config map[string]interface{}) (filePath, tableName, dataset st
 }
 
 func parseColumns(config map[string]interface{}, filePath string) ([]string, error) {
-	if rawCols, ok := config["columns"].([]interface{}); ok && len(rawCols) > 0 {
-		cols := make([]string, 0, len(rawCols))
-		for _, c := range rawCols {
-			s, ok := c.(string)
-			if ok && s != "" {
-				cols = append(cols, s)
-			}
-		}
-		if len(cols) > 0 {
-			return cols, nil
-		}
+	headers, err := readCSVHeaders(filePath)
+	if err != nil {
+		return nil, err
 	}
 
+	rawCols, ok := config["columns"].([]interface{})
+	if !ok || len(rawCols) == 0 {
+		return headers, nil
+	}
+
+	cols := make([]string, 0, len(rawCols))
+	for i, c := range rawCols {
+		s, ok := c.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			return nil, fmt.Errorf("columns[%d] must be a non-empty string", i)
+		}
+		cols = append(cols, s)
+	}
+
+	headerSet := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		headerSet[header] = struct{}{}
+	}
+
+	var missing []string
+	for _, col := range cols {
+		if _, ok := headerSet[col]; !ok {
+			missing = append(missing, col)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("columns not found in CSV header: %s", strings.Join(missing, ", "))
+	}
+
+	return cols, nil
+}
+
+func readCSVHeaders(filePath string) ([]string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, err

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -23,3 +23,39 @@ func TestReadCSVDocumentsReturnsParseError(t *testing.T) {
 		t.Fatalf("expected row number in error, got %v", err)
 	}
 }
+
+func TestParseColumnsRejectsUnknownConfiguredColumns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(path, []byte("id,title\n1,ok\n"), 0644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	_, err := parseColumns(map[string]interface{}{
+		"columns": []interface{}{"id", "missing"},
+	}, path)
+	if err == nil {
+		t.Fatal("expected parseColumns to reject unknown configured columns")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected missing column name in error, got %v", err)
+	}
+}
+
+func TestParseColumnsRejectsEmptyConfiguredColumn(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(path, []byte("id,title\n1,ok\n"), 0644); err != nil {
+		t.Fatalf("write csv: %v", err)
+	}
+
+	_, err := parseColumns(map[string]interface{}{
+		"columns": []interface{}{"id", ""},
+	}, path)
+	if err == nil {
+		t.Fatal("expected parseColumns to reject empty configured column names")
+	}
+	if !strings.Contains(err.Error(), "columns[1]") {
+		t.Fatalf("expected column index in error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make loader drop mirror loader load by skipping undefined dataset backends and failing the command when drops fail
- validate configured CSV columns strictly, honor AWS_REGION for anonymous S3 pulls, and add regression coverage
- tighten sample docs and shorten the default sample benchmark so the quick start path matches the services it asks users to run

## Testing
- /bin/zsh -lc "mkdir -p .gocache .gomodcache && GOCACHE=/private/tmp/benchmarks-pr-loader/.gocache GOMODCACHE=/private/tmp/benchmarks-pr-loader/.gomodcache go test ./..."