### PR TITLE
fix: Fix dashboard duration and stale panel state

### DIFF
--- a/cmd/dashboard-viewer/main.go
+++ b/cmd/dashboard-viewer/main.go
@@ -1,4 +1,4 @@
-// Command dashboard-viewer serves saved k6-search dashboard JSON files.
+// Command dashboard-viewer serves saved benchmark dashboard JSON files.
 //
 // Usage:
 //
@@ -17,7 +17,7 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: dashboard-viewer <dashboard.json> [--export <output.html>] [--notes \"Description\"]")
-		fmt.Println("\nViews a saved k6-search dashboard JSON file in your browser.")
+		fmt.Println("\nViews a saved benchmark dashboard JSON file in your browser.")
 		fmt.Println("Use --export to create a single-file HTML viewer with embedded dashboard data.")
 		fmt.Println("The exported HTML still loads frontend assets from CDNs.")
 		fmt.Println("Use --notes to add a description below the title.")

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -1,4 +1,4 @@
-// Package dashboard provides a web-based dashboard for k6 search benchmarks.
+// Package dashboard provides a web-based dashboard for benchmark runs.
 package dashboard
 
 import (
@@ -43,10 +43,9 @@ type Output struct {
 
 // DashboardData holds all metrics for the dashboard.
 type DashboardData struct {
-	StartTime     time.Time                    `json:"startTime"`
-	TotalDuration float64                      `json:"totalDuration"` // Total test duration in seconds
-	Runs          map[string]*RunMetrics       `json:"runs"`
-	Containers    map[string]*ContainerMetrics `json:"-"` // Container metrics by container name (independent of runs)
+	StartTime  time.Time                    `json:"startTime"`
+	Runs       map[string]*RunMetrics       `json:"runs"`
+	Containers map[string]*ContainerMetrics `json:"-"` // Container metrics by container name (independent of runs)
 }
 
 // ContainerMetrics holds CPU/memory metrics for a container.
@@ -70,7 +69,6 @@ type RunMetrics struct {
 	Color           string                   `json:"color"`     // Custom color for this backend
 	Chart           string                   `json:"chart"`     // Chart group for separating graphs
 	Latencies       []float64                `json:"latencies"`
-	Timeline        []TimelinePoint          `json:"timeline"`
 	IngestRate      []TimeValue              `json:"ingestRate"`    // Docs/sec timeline
 	TotalIngested   int64                    `json:"totalIngested"` // Total docs ingested
 	FirstIngestTime int64                    `json:"-"`             // Timestamp of the first ingest sample
@@ -608,6 +606,38 @@ func (o *Output) broadcast() {
 	o.mu.Unlock()
 }
 
+func latestRunTime(rm *RunMetrics) int64 {
+	latest := rm.StartTime
+	if rm.EndTime > latest {
+		latest = rm.EndTime
+	}
+	if rm.LastUpdateTime > latest {
+		latest = rm.LastUpdateTime
+	}
+	if rm.LastIngestTime > latest {
+		latest = rm.LastIngestTime
+	}
+	if len(rm.IngestRate) > 0 {
+		if t := rm.IngestRate[len(rm.IngestRate)-1].Time; t > latest {
+			latest = t
+		}
+	}
+	for _, qm := range rm.Queries {
+		if qm.StartTime > latest {
+			latest = qm.StartTime
+		}
+		if qm.EndTime > latest {
+			latest = qm.EndTime
+		}
+		if len(qm.Timeline) > 0 {
+			if t := qm.Timeline[len(qm.Timeline)-1].Time; t > latest {
+				latest = t
+			}
+		}
+	}
+	return latest
+}
+
 func (o *Output) getSummary() map[string]interface{} {
 	elapsed := time.Since(o.data.StartTime).Seconds()
 	now := time.Now().UnixMilli()
@@ -616,31 +646,18 @@ func (o *Output) getSummary() map[string]interface{} {
 	var maxRunDuration float64
 	for _, rm := range o.data.Runs {
 		if rm.StartTime > 0 {
-			var runDuration float64
-			if rm.EndTime > 0 {
-				runDuration = float64(rm.EndTime-rm.StartTime) / 1000
-			} else {
-				// Check query timelines for last data point
-				var lastTime int64
-				for _, qm := range rm.Queries {
-					if len(qm.Timeline) > 0 {
-						if t := qm.Timeline[len(qm.Timeline)-1].Time; t > lastTime {
-							lastTime = t
-						}
-					}
-				}
-				if lastTime > 0 {
-					runDuration = float64(lastTime-rm.StartTime) / 1000
-				}
+			runEnd := latestRunTime(rm)
+			if runEnd <= rm.StartTime {
+				continue
 			}
+			runDuration := float64(runEnd-rm.StartTime) / 1000
 			if runDuration > maxRunDuration {
 				maxRunDuration = runDuration
 			}
 		}
 	}
-	// Use totalDuration if set, otherwise use max run duration + buffer
-	chartDuration := o.data.TotalDuration
-	if chartDuration == 0 && maxRunDuration > 0 {
+	chartDuration := 0.0
+	if maxRunDuration > 0 {
 		chartDuration = maxRunDuration + 5 // Add 5 second buffer
 	}
 	if chartDuration == 0 {

--- a/dashboard/output_test.go
+++ b/dashboard/output_test.go
@@ -92,6 +92,31 @@ func TestGetSummaryUsesQueryWindowForQPS(t *testing.T) {
 	}
 }
 
+func TestGetSummaryUsesLastRunActivityForChartDuration(t *testing.T) {
+	o := &Output{
+		data: &DashboardData{
+			StartTime: time.Unix(0, 0),
+			Runs: map[string]*RunMetrics{
+				"ingest": {
+					Name:            "ingest",
+					Backend:         "paradedb",
+					StartTime:       1000,
+					LastUpdateTime:  6000,
+					FirstIngestTime: 1000,
+					TotalIngested:   300,
+					Queries:         map[string]*QueryMetrics{},
+				},
+			},
+		},
+	}
+
+	summary := o.getSummary()
+	got := summary["chartDuration"].(float64)
+	if math.Abs(got-10.0) > 0.001 {
+		t.Fatalf("expected chart duration of 10.0 seconds, got %.3f", got)
+	}
+}
+
 func TestRecordRunActivityReopensEndedRun(t *testing.T) {
 	rm := &RunMetrics{
 		StartTime: 1000,

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -656,6 +656,32 @@
       let chartLegendKeys = {}; // Legend keys per dashboard group
       let chartGroupOrder = []; // Track order of chart groups by first emission
 
+      function clearNotes() {
+        const notesContainer = document.getElementById("notes-container");
+        notesContainer.textContent = "";
+        notesContainer.style.display = "none";
+      }
+
+      function clearMetricsPanel() {
+        document.getElementById("metrics-container").style.display = "none";
+        [cpuChart, memoryChart].forEach((chart) => {
+          chart.data.datasets = [];
+          delete chart.options.scales.y.min;
+          delete chart.options.scales.y.max;
+          chart.update("none");
+        });
+      }
+
+      function clearIngestPanel() {
+        document.getElementById("ingest-legend").innerHTML = "";
+        document.getElementById("ingest-stats-container").innerHTML = "";
+        document.getElementById("ingest-container").style.display = "none";
+        ingestChart.data.datasets = [];
+        delete ingestChart.options.scales.y.min;
+        delete ingestChart.options.scales.y.max;
+        ingestChart.update("none");
+      }
+
       function resetState() {
         runColors = {};
         colorIndex = 0;
@@ -673,10 +699,10 @@
           .querySelectorAll(".reset-zoom")
           .forEach((btn) => btn.classList.remove("visible"));
         document.getElementById("chart-groups-container").innerHTML = "";
-        document.getElementById("ingest-legend").innerHTML = "";
         chartLegendKeys = {};
-        document.getElementById("ingest-stats-container").innerHTML = "";
-        document.getElementById("ingest-container").style.display = "none";
+        clearNotes();
+        clearMetricsPanel();
+        clearIngestPanel();
         // Destroy existing dashboard charts
         Object.values(chartInstances).forEach((chart) => chart.destroy());
         chartInstances = {};
@@ -686,6 +712,7 @@
           chart.options.scales.x.min = 0;
           chart.options.scales.x.max = chartDuration;
           delete chart.options.scales.y.max;
+          delete chart.options.scales.y.min;
           chart.update("none");
         });
       }
@@ -1785,6 +1812,8 @@
         if (data.notes) {
           notesContainer.textContent = data.notes;
           notesContainer.style.display = "block";
+        } else {
+          clearNotes();
         }
 
         const runs = data.runs || {};
@@ -1974,6 +2003,8 @@
           updateChartDatasets(memoryChart, memoryDatasets);
           updateChartYAxis(memoryChart);
           memoryChart.update("none");
+        } else {
+          clearMetricsPanel();
         }
 
         // Update ingest chart (only if any run has ingest data)
@@ -2041,6 +2072,8 @@
           updateChartDatasets(ingestChart, ingestDatasets);
           updateChartYAxis(ingestChart);
           ingestChart.update("none");
+        } else {
+          clearIngestPanel();
         }
       }
 


### PR DESCRIPTION
## Summary
- compute chart duration from each run's latest observed activity so ingest-only active runs expand correctly
- clear notes, resource panels, and ingest panels when fresh dashboard payloads no longer include that data
- remove dead dashboard fields and update dashboard-viewer help text to match current naming

## Testing
- /bin/zsh -lc "mkdir -p .gocache .gomodcache && GOCACHE=/private/tmp/benchmarks-pr-dashboard/.gocache GOMODCACHE=/private/tmp/benchmarks-pr-dashboard/.gomodcache go test ./..."