### PR TITLE
chore: Harden elastic aggregation and TLS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,9 @@ export CLICKHOUSE_URL="clickhouse://default:clickhouse@localhost:9000/default"
 export MONGODB_URL="mongodb://localhost:27017"
 ```
 
+For self-signed HTTPS OpenSearch development clusters, set `OPENSEARCH_SKIP_TLS_VERIFY=true`.
+Leave it unset to keep certificate verification enabled.
+
 Or configure per-backend:
 
 ```javascript

--- a/backends/opensearch/register.go
+++ b/backends/opensearch/register.go
@@ -2,9 +2,15 @@
 package opensearch
 
 import (
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/paradedb/benchmarks/backends"
 	"github.com/paradedb/benchmarks/backends/shared/elastic"
 )
+
+const skipTLSVerifyEnv = "OPENSEARCH_SKIP_TLS_VERIFY"
 
 func init() {
 	backends.Register("opensearch", backends.BackendConfig{
@@ -16,10 +22,26 @@ func init() {
 	})
 }
 
+func driverConfig() elastic.DriverConfig {
+	return elastic.DriverConfig{
+		SkipTLSVerify:    envBool(skipTLSVerifyEnv),
+		VersionInfoField: "distribution",
+	}
+}
+
+func envBool(name string) bool {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return false
+	}
+	return enabled
+}
+
 // New creates a new OpenSearch driver.
 func New(connString string) (backends.Driver, error) {
-	return elastic.New(connString, elastic.DriverConfig{
-		SkipTLSVerify:    true,
-		VersionInfoField: "distribution",
-	})
+	return elastic.New(connString, driverConfig())
 }

--- a/backends/opensearch/register_test.go
+++ b/backends/opensearch/register_test.go
@@ -1,0 +1,30 @@
+package opensearch
+
+import "testing"
+
+func TestDriverConfigDefaultsToVerifiedTLS(t *testing.T) {
+	t.Setenv(skipTLSVerifyEnv, "")
+
+	config := driverConfig()
+	if config.SkipTLSVerify {
+		t.Fatal("expected TLS verification to remain enabled by default")
+	}
+}
+
+func TestDriverConfigAllowsOptInTLSBypass(t *testing.T) {
+	t.Setenv(skipTLSVerifyEnv, "true")
+
+	config := driverConfig()
+	if !config.SkipTLSVerify {
+		t.Fatal("expected TLS verification bypass to be enabled when requested")
+	}
+}
+
+func TestDriverConfigIgnoresInvalidTLSBypassValues(t *testing.T) {
+	t.Setenv(skipTLSVerifyEnv, "definitely-not-bool")
+
+	config := driverConfig()
+	if config.SkipTLSVerify {
+		t.Fatal("expected invalid TLS bypass values to fall back to secure default")
+	}
+}

--- a/backends/shared/elastic/driver.go
+++ b/backends/shared/elastic/driver.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 
 // DriverConfig holds backend-specific configuration.
 type DriverConfig struct {
-	SkipTLSVerify    bool   // OpenSearch often uses self-signed certs
+	SkipTLSVerify    bool   // Allows self-signed HTTPS endpoints in development.
 	VersionInfoField string // "build_flavor" for ES, "distribution" for OS
 }
 
@@ -171,6 +172,38 @@ func (d *Driver) execOperations(ctx context.Context, operations []map[string]int
 	return nil
 }
 
+type aggregationResult struct {
+	Buckets []interface{} `json:"buckets"`
+	Value   *float64      `json:"value"` // for cardinality/single-value aggs
+}
+
+func aggregationHitCount(aggregations map[string]aggregationResult) (int, bool) {
+	if len(aggregations) == 0 {
+		return 0, false
+	}
+
+	keys := make([]string, 0, len(aggregations))
+	for key := range aggregations {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Prefer bucket aggregations because they represent grouped result sets.
+	for _, key := range keys {
+		if count := len(aggregations[key].Buckets); count > 0 {
+			return count, true
+		}
+	}
+
+	for _, key := range keys {
+		if value := aggregations[key].Value; value != nil {
+			return int(*value), true
+		}
+	}
+
+	return 0, false
+}
+
 // Query executes a search query and returns the hit count.
 // Supports two call patterns:
 //   - Query(ctx, jsonQueryString) - query is a JSON string
@@ -229,10 +262,7 @@ func (d *Driver) Query(ctx context.Context, query string, args ...any) (int, err
 			} `json:"total"`
 			Hits []interface{} `json:"hits"`
 		} `json:"hits"`
-		Aggregations map[string]struct {
-			Buckets []interface{} `json:"buckets"`
-			Value   *float64      `json:"value"` // for cardinality/single-value aggs
-		} `json:"aggregations"`
+		Aggregations map[string]aggregationResult `json:"aggregations"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return 0, err
@@ -243,16 +273,9 @@ func (d *Driver) Query(ctx context.Context, query string, args ...any) (int, err
 		return len(result.Hits.Hits), nil
 	}
 
-	// For aggregations, return bucket count or single value
-	if len(result.Aggregations) > 0 {
-		for _, agg := range result.Aggregations {
-			if len(agg.Buckets) > 0 {
-				return len(agg.Buckets), nil
-			}
-			if agg.Value != nil {
-				return int(*agg.Value), nil
-			}
-		}
+	// For aggregations, return a deterministic bucket count or single value.
+	if count, ok := aggregationHitCount(result.Aggregations); ok {
+		return count, nil
 	}
 
 	// Fall back to total hits (for count queries with size:0)

--- a/backends/shared/elastic/driver_test.go
+++ b/backends/shared/elastic/driver_test.go
@@ -1,0 +1,44 @@
+package elastic
+
+import "testing"
+
+func TestAggregationHitCountPrefersBuckets(t *testing.T) {
+	value := 7.0
+	aggregations := map[string]aggregationResult{
+		"z_terms": {
+			Buckets: []interface{}{"a", "b", "c"},
+		},
+		"a_cardinality": {
+			Value: &value,
+		},
+	}
+
+	got, ok := aggregationHitCount(aggregations)
+	if !ok {
+		t.Fatal("expected aggregation hit count to be present")
+	}
+	if got != 3 {
+		t.Fatalf("expected bucket count of 3, got %d", got)
+	}
+}
+
+func TestAggregationHitCountUsesSortedKeysForSingleValueAggs(t *testing.T) {
+	first := 5.0
+	second := 9.0
+	aggregations := map[string]aggregationResult{
+		"z_count": {
+			Value: &second,
+		},
+		"a_count": {
+			Value: &first,
+		},
+	}
+
+	got, ok := aggregationHitCount(aggregations)
+	if !ok {
+		t.Fatal("expected aggregation hit count to be present")
+	}
+	if got != 5 {
+		t.Fatalf("expected sorted first aggregation value of 5, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- make Elasticsearch/OpenSearch aggregation hit counting deterministic and add regression coverage for multi-aggregation responses
- require TLS verification for OpenSearch by default, with an explicit OPENSEARCH_SKIP_TLS_VERIFY escape hatch for self-signed HTTPS dev clusters
- document the OpenSearch TLS override in the README

## Testing
- /bin/zsh -lc "mkdir -p .gocache .gomodcache && GOCACHE=/private/tmp/benchmarks-pr-elastic/.gocache GOMODCACHE=/private/tmp/benchmarks-pr-elastic/.gomodcache go test ./..."