### PR TITLE
fix: Fix gofmt, errcheck, and trailing whitespace

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,4 @@
 MD013: false # Line length
 MD034: false # Bare URLs (used for local dashboard examples)
+MD033: false # Inline HTML (README uses centered HTML headings/badges)
+MD060: false # Table column style (pipe alignment is cosmetic, renderers ignore it)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,14 +111,14 @@ type Driver interface {
 }
 ```
 
-| Method          | Purpose |
-| --------------- | ------- |
-| `Close`         | Clean up connections |
-| `Exec`          | Run setup/teardown statements (pre/post scripts) |
-| `Query`         | Execute a search query and return the hit count |
-| `Insert`        | Bulk insert rows, return count inserted |
+| Method          | Purpose                                               |
+| --------------- | ----------------------------------------------------- |
+| `Close`         | Clean up connections                                  |
+| `Exec`          | Run setup/teardown statements (pre/post scripts)      |
+| `Query`         | Execute a search query and return the hit count       |
+| `Insert`        | Bulk insert rows, return count inserted               |
 | `Update`        | Bulk upsert rows by key columns, return count updated |
-| `CaptureConfig` | Capture backend version/settings for the dashboard |
+| `CaptureConfig` | Capture backend version/settings for the dashboard    |
 
 ### 2. Use a Shared Driver or Write Your Own
 
@@ -198,13 +198,13 @@ datasets/sample/mybackend/
 
 ### BackendConfig Fields
 
-| Field         | Description |
-| ------------- | ----------- |
+| Field         | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
 | `Factory`     | `func(connString string) (Driver, error)` — creates a driver instance |
-| `FileType`    | `"sql"` or `"json"` — determines pre/post script file extension |
-| `EnvVar`      | Environment variable name for the connection string |
-| `DefaultConn` | Fallback connection string when env var is unset |
-| `Container`   | Docker container name for metrics collection |
+| `FileType`    | `"sql"` or `"json"` — determines pre/post script file extension       |
+| `EnvVar`      | Environment variable name for the connection string                   |
+| `DefaultConn` | Fallback connection string when env var is unset                      |
+| `Container`   | Docker container name for metrics collection                          |
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project extends k6 with the `k6/x/database` module, adding backend drivers,
 
 A single script can compose multiple scenarios across multiple backends. You might run queries against ParadeDB for 30 seconds, then against Elasticsearch for 30 seconds, with a built-in phase timer staggering them so they don't compete for system resources. Within each phase you can layer different workloads: a full-text search at 200 QPS, an aggregation query at 100 QPS, and a 1,000 row/s ingest stream, all running concurrently. The framework times every operation, tags it with the backend name, and pushes metrics to the dashboard automatically.
 
-While the framework exposes many backends, it's up to the user to write the queries to test (in JSON or SQL). A user can expect that the *way* the queries are run is optimal, but must still make sure the content of the queries is sane.
+While the framework exposes many backends, it's up to the user to write the queries to test (in JSON or SQL). A user can expect that the _way_ the queries are run is optimal, but must still make sure the content of the queries is sane.
 
 ### Ingest & update workloads
 
@@ -118,18 +118,21 @@ const scenarios = {
 
 // Add docker based metric collection
 backends.addDockerMetricsCollector(scenarios, "35s");
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 
 // Create the function which k6 will call on each iteration
 export function paradedbQuery() {
-
-// Activate the paradedb backend and run the query, cycling through the items in terms
-  backends.get("paradedb").query(
-    `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
-    terms.next(),
-  );
+  // Activate the paradedb backend and run the query, cycling through the items in terms
+  backends
+    .get("paradedb")
+    .query(
+      `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
+      terms.next(),
+    );
 }
 ```
 
@@ -139,14 +142,14 @@ The [Scripting Guide](docs/scripting.md) covers the full module API, backend con
 
 ## Documentation
 
-| Guide | Description |
-| --- | --- |
+| Guide                                | Description                                                     |
+| ------------------------------------ | --------------------------------------------------------------- |
 | [Scripting Guide](docs/scripting.md) | Module API, backend config, benchmark patterns, query reference |
-| [Dashboard](docs/dashboard.md) | Real-time UI, metrics reference, export & replay |
-| [Datasets](docs/datasets.md) | Directory structure, schema format, pre/post scripts |
-| [Data Loader](docs/loader.md) | CLI usage, connection strings, S3 pulls |
-| [Docker Setup](docs/docker.md) | Compose profiles, service ports, TLS |
-| [Contributing](CONTRIBUTING.md) | Adding backends, development setup, PR workflow |
+| [Dashboard](docs/dashboard.md)       | Real-time UI, metrics reference, export & replay                |
+| [Datasets](docs/datasets.md)         | Directory structure, schema format, pre/post scripts            |
+| [Data Loader](docs/loader.md)        | CLI usage, connection strings, S3 pulls                         |
+| [Docker Setup](docs/docker.md)       | Compose profiles, service ports, TLS                            |
+| [Contributing](CONTRIBUTING.md)      | Adding backends, development setup, PR workflow                 |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ make
 
 ### 2. Start backends
 
-The included `docker-compose.yml` uses profiles, which provide an easy way to only spin up a subset of containers. 
+The included `docker-compose.yml` uses profiles, which provide an easy way to only spin up a subset of containers.
 
 Please note the 'sample' dataset which is included does not provide a meaningful benchmark, it's designed to show how to use the system.
 

--- a/backends.go
+++ b/backends.go
@@ -17,7 +17,7 @@ import (
 	_ "github.com/paradedb/benchmarker/backends/mongodb"
 	_ "github.com/paradedb/benchmarker/backends/opensearch"
 	_ "github.com/paradedb/benchmarker/backends/paradedb"
-_ "github.com/paradedb/benchmarker/backends/postgresfts"
+	_ "github.com/paradedb/benchmarker/backends/postgresfts"
 )
 
 // Backends holds all configured backend clients.
@@ -200,12 +200,14 @@ func (b *Backends) AddDockerMetricsCollector(call sobek.FunctionCall) sobek.Valu
 		}
 	}
 
-	scenarios.Set("metrics_collector", rt.ToValue(map[string]interface{}{
+	if err := scenarios.Set("metrics_collector", rt.ToValue(map[string]interface{}{
 		"executor": "constant-vus",
 		"vus":      1,
 		"duration": dur,
 		"exec":     "collectMetrics",
-	}))
+	})); err != nil {
+		common.Throw(rt, fmt.Errorf("failed to set metrics_collector scenario: %w", err))
+	}
 
 	return rt.ToValue(func() map[string]interface{} {
 		return b.Collect()

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -47,23 +47,23 @@ make viewer
 
 The extension emits standard k6 metrics with backend tags:
 
-| Metric                   | Type    | Description                                  |
-| ------------------------ | ------- | -------------------------------------------- |
-| `query_duration`         | Trend   | Query latency in milliseconds                |
-| `query_hits`             | Gauge   | Number of results returned                   |
-| `ingest_duration`        | Trend   | Insert latency in milliseconds               |
-| `ingest_docs`            | Counter | Documents inserted                           |
-| `update_duration`        | Trend   | Update latency in milliseconds               |
-| `update_docs`            | Counter | Documents updated                            |
-| `backend_init`           | Gauge   | Signals a backend is configured              |
-| `scenario_started`       | Gauge   | Signals a scenario has begun                 |
-| `container_cpu_percent`  | Gauge   | Container CPU usage percentage               |
-| `container_memory_bytes` | Gauge   | Container memory usage                       |
+| Metric                   | Type    | Description                     |
+| ------------------------ | ------- | ------------------------------- |
+| `query_duration`         | Trend   | Query latency in milliseconds   |
+| `query_hits`             | Gauge   | Number of results returned      |
+| `ingest_duration`        | Trend   | Insert latency in milliseconds  |
+| `ingest_docs`            | Counter | Documents inserted              |
+| `update_duration`        | Trend   | Update latency in milliseconds  |
+| `update_docs`            | Counter | Documents updated               |
+| `backend_init`           | Gauge   | Signals a backend is configured |
+| `scenario_started`       | Gauge   | Signals a scenario has begun    |
+| `container_cpu_percent`  | Gauge   | Container CPU usage percentage  |
+| `container_memory_bytes` | Gauge   | Container memory usage          |
 
 ## Environment Variables
 
-| Variable                | Default | Description                                            |
-| ----------------------- | ------- | ------------------------------------------------------ |
-| `DASHBOARD_EXPORT`      | `false` | Set to `true` to save a JSON snapshot when the test ends |
-| `DASHBOARD_BROADCAST_MS`| `200`   | SSE broadcast interval in milliseconds                 |
-| `DASHBOARD_WINDOW_MS`   | `1000`  | Sliding window for timeline percentile aggregation (0 for non-overlapping buckets) |
+| Variable                 | Default | Description                                                                        |
+| ------------------------ | ------- | ---------------------------------------------------------------------------------- |
+| `DASHBOARD_EXPORT`       | `false` | Set to `true` to save a JSON snapshot when the test ends                           |
+| `DASHBOARD_BROADCAST_MS` | `200`   | SSE broadcast interval in milliseconds                                             |
+| `DASHBOARD_WINDOW_MS`    | `1000`  | Sliding window for timeline percentile aggregation (0 for non-overlapping buckets) |

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -30,7 +30,9 @@ const scenarios = {
 
 // 4. Add Docker metrics collector
 backends.addDockerMetricsCollector(scenarios, timer);
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 
@@ -50,13 +52,13 @@ export function queryTest() {
 
 The `db` module (`k6/x/database`) provides:
 
-| Function | Returns | Description |
-| --- | --- | --- |
-| `db.backends(config)` | `Backends` | Initializes backend drivers and Docker metrics collector from config |
-| `db.metrics(config)` | `Collector` | Creates a standalone Docker container metrics collector (use `backends.addDockerMetricsCollector()` instead for most cases) |
-| `db.timer({ duration, gap })` | `Timer` | Creates a phase timer for staggering scenarios |
-| `db.loader()` | `Loader` | Creates a CSV document reader for ingest or update benchmarks |
-| `db.terms(data)` | `Terms` | Loads a JSON array of query strings to avoid caching bias. `terms.next()` cycles sequentially, `terms.random()` picks randomly. Accepts a JSON string via `open()` or a k6 `SharedArray`. |
+| Function                      | Returns     | Description                                                                                                                                                                               |
+| ----------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `db.backends(config)`         | `Backends`  | Initializes backend drivers and Docker metrics collector from config                                                                                                                      |
+| `db.metrics(config)`          | `Collector` | Creates a standalone Docker container metrics collector (use `backends.addDockerMetricsCollector()` instead for most cases)                                                               |
+| `db.timer({ duration, gap })` | `Timer`     | Creates a phase timer for staggering scenarios                                                                                                                                            |
+| `db.loader()`                 | `Loader`    | Creates a CSV document reader for ingest or update benchmarks                                                                                                                             |
+| `db.terms(data)`              | `Terms`     | Loads a JSON array of query strings to avoid caching bias. `terms.next()` cycles sequentially, `terms.random()` picks randomly. Accepts a JSON string via `open()` or a k6 `SharedArray`. |
 
 ## Backend Configuration
 
@@ -89,24 +91,24 @@ The framework is database-agnostic - the current backends and datasets are focus
 
 **PostgreSQL-based** (shared driver, different extensions):
 
-| Type            | Description                              |
-| --------------- | ---------------------------------------- |
-| `paradedb`      | ParadeDB with pg_search (BM25)           |
-| `postgresfts`   | PostgreSQL native FTS (tsvector/tsquery) |
+| Type          | Description                              |
+| ------------- | ---------------------------------------- |
+| `paradedb`    | ParadeDB with pg_search (BM25)           |
+| `postgresfts` | PostgreSQL native FTS (tsvector/tsquery) |
 
 **Elasticsearch-based** (shared driver):
 
-| Type            | Description |
-| --------------- | ----------- |
+| Type            | Description   |
+| --------------- | ------------- |
 | `elasticsearch` | Elasticsearch |
 | `opensearch`    | OpenSearch    |
 
 **Other**:
 
-| Type            | Description               |
-| --------------- | ------------------------- |
-| `clickhouse`    | ClickHouse                |
-| `mongodb`       | MongoDB with Atlas Search |
+| Type         | Description               |
+| ------------ | ------------------------- |
+| `clickhouse` | ClickHouse                |
+| `mongodb`    | MongoDB with Atlas Search |
 
 ## Benchmark Patterns
 
@@ -116,29 +118,29 @@ The framework is database-agnostic - the current backends and datasets are focus
 
 k6 provides several executors that determine how virtual users are scheduled:
 
-| Executor                 | Description                                                    | Best for                             |
-| ------------------------ | -------------------------------------------------------------- | ------------------------------------ |
-| `constant-vus`           | Fixed number of VUs running for a set duration                 | Most query benchmarks                |
-| `constant-arrival-rate`  | Fixed iteration rate regardless of response time               | Rate-limited ingest, SLA testing     |
-| `ramping-vus`            | VUs increase/decrease over stages                              | Load ramp-up, finding breaking point |
-| `ramping-arrival-rate`   | Iteration rate increases/decreases over stages                 | Gradual load increase testing        |
+| Executor                | Description                                      | Best for                             |
+| ----------------------- | ------------------------------------------------ | ------------------------------------ |
+| `constant-vus`          | Fixed number of VUs running for a set duration   | Most query benchmarks                |
+| `constant-arrival-rate` | Fixed iteration rate regardless of response time | Rate-limited ingest, SLA testing     |
+| `ramping-vus`           | VUs increase/decrease over stages                | Load ramp-up, finding breaking point |
+| `ramping-arrival-rate`  | Iteration rate increases/decreases over stages   | Gradual load increase testing        |
 
 k6 provides [additional executors](https://grafana.com/docs/k6/latest/using-k6/scenarios/executors/) for other use cases.
 
 Each scenario specifies:
 
-| Option            | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| `executor`        | How VUs are scheduled (see table above)                       |
-| `vus`             | Number of virtual users (for VU-based executors)              |
-| `duration`        | How long the scenario runs                                    |
-| `startTime`       | When to start (for sequential phases)                         |
-| `exec`            | Which exported function to run                                |
-| `tags`            | Custom tags for grouping metrics in charts                    |
-| `env`             | Per-scenario environment variables (readable via `__ENV`)     |
-| `rate`            | Iterations per `timeUnit` (arrival-rate executors)            |
-| `timeUnit`        | Time unit for `rate` (e.g., `"1s"`)                           |
-| `preAllocatedVUs` | VUs pre-allocated for arrival-rate executors                  |
+| Option            | Description                                               |
+| ----------------- | --------------------------------------------------------- |
+| `executor`        | How VUs are scheduled (see table above)                   |
+| `vus`             | Number of virtual users (for VU-based executors)          |
+| `duration`        | How long the scenario runs                                |
+| `startTime`       | When to start (for sequential phases)                     |
+| `exec`            | Which exported function to run                            |
+| `tags`            | Custom tags for grouping metrics in charts                |
+| `env`             | Per-scenario environment variables (readable via `__ENV`) |
+| `rate`            | Iterations per `timeUnit` (arrival-rate executors)        |
+| `timeUnit`        | Time unit for `rate` (e.g., `"1s"`)                       |
+| `preAllocatedVUs` | VUs pre-allocated for arrival-rate executors              |
 
 ### Pattern 1: Single Backend
 
@@ -154,15 +156,19 @@ const scenarios = {
   },
 };
 backends.addDockerMetricsCollector(scenarios, "35s");
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 
 export function pdbQuery() {
-  backends.get("paradedb").query(
-    `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
-    terms.next(),
-  );
+  backends
+    .get("paradedb")
+    .query(
+      `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
+      terms.next(),
+    );
 }
 ```
 
@@ -209,7 +215,9 @@ const scenarios = {
 
 // Adds a metrics_collector scenario covering the full test duration
 backends.addDockerMetricsCollector(scenarios, timer);
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 ```
@@ -273,15 +281,19 @@ const scenarios = {
   },
 };
 backends.addDockerMetricsCollector(scenarios, timer);
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 
 export function pdbQuery() {
-  backends.get("paradedb").query(
-    `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
-    terms.next(),
-  );
+  backends
+    .get("paradedb")
+    .query(
+      `SELECT id, title FROM documents WHERE content ||| $1 LIMIT 10`,
+      terms.next(),
+    );
 }
 
 export function esQuery() {
@@ -342,7 +354,9 @@ const scenarios = {
   },
 };
 backends.addDockerMetricsCollector(scenarios, timer);
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 ```
@@ -359,17 +373,19 @@ const scenarios = {
     executor: "ramping-vus",
     startVUs: 1,
     stages: [
-      { duration: "30s", target: 10 },   // Ramp up to 10 VUs
-      { duration: "60s", target: 10 },   // Hold at 10
-      { duration: "30s", target: 50 },   // Ramp up to 50 VUs
-      { duration: "60s", target: 50 },   // Hold at 50
-      { duration: "30s", target: 0 },    // Ramp down
+      { duration: "30s", target: 10 }, // Ramp up to 10 VUs
+      { duration: "60s", target: 10 }, // Hold at 10
+      { duration: "30s", target: 50 }, // Ramp up to 50 VUs
+      { duration: "60s", target: 50 }, // Hold at 50
+      { duration: "30s", target: 0 }, // Ramp down
     ],
     exec: "queryTest",
   },
 };
 backends.addDockerMetricsCollector(scenarios, "220s");
-export function collectMetrics() { backends.collect(); }
+export function collectMetrics() {
+  backends.collect();
+}
 
 export const options = { scenarios };
 ```
@@ -402,11 +418,11 @@ The `nextBatchSwapped()` method lazily builds a copy of all documents with adjac
 
 Each backend returned by `backends.get()` also exposes:
 
-| Method | Description |
-| --- | --- |
-| `setTimeout(seconds)` | Set the query timeout for this backend |
-| `insert(table, doc)` | Insert a single document |
-| `update(table, doc)` | Update a single document (keyed by `id` or `_id`) |
+| Method                | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `setTimeout(seconds)` | Set the query timeout for this backend            |
+| `insert(table, doc)`  | Insert a single document                          |
+| `update(table, doc)`  | Update a single document (keyed by `id` or `_id`) |
 
 Call `backends.setTimeout(seconds)` to set the timeout on all backends at once, or `backends.close()` to close all connections.
 
@@ -418,18 +434,28 @@ The loader can also bulk-load data directly from a k6 script (without the CLI). 
 const loader = db.loader();
 
 // Generic: specify backend name and connection string
-loader.load("paradedb", "postgres://postgres:postgres@localhost:5432/benchmark", {
-  file: "../data.csv",
-  table: "documents",
-  dataset: "../",
-  batchSize: 10000,
-});
+loader.load(
+  "paradedb",
+  "postgres://postgres:postgres@localhost:5432/benchmark",
+  {
+    file: "../data.csv",
+    table: "documents",
+    dataset: "../",
+    batchSize: 10000,
+  },
+);
 
 // Backend-specific helpers
 loader.loadParadeDB("postgres://...", { file: "../data.csv", dataset: "../" });
-loader.loadPostgresFTS("postgres://...", { file: "../data.csv", dataset: "../" });
+loader.loadPostgresFTS("postgres://...", {
+  file: "../data.csv",
+  dataset: "../",
+});
 loader.loadElasticsearch({ file: "../data.csv", dataset: "../" });
-loader.loadClickHouse("clickhouse://...", { file: "../data.csv", dataset: "../" });
+loader.loadClickHouse("clickhouse://...", {
+  file: "../data.csv",
+  dataset: "../",
+});
 loader.loadMongoDB("mongodb://...", { file: "../data.csv", dataset: "../" });
 ```
 

--- a/metrics/results.go
+++ b/metrics/results.go
@@ -13,8 +13,8 @@ import (
 
 var (
 	// Unified metrics - tagged by backend
-	queryDuration  *metrics.Metric
-	queryHits      *metrics.Metric
+	queryDuration   *metrics.Metric
+	queryHits       *metrics.Metric
 	ingestDuration  *metrics.Metric
 	ingestDocs      *metrics.Metric
 	updateDuration  *metrics.Metric

--- a/timer_test.go
+++ b/timer_test.go
@@ -87,9 +87,9 @@ func TestTotalDurationSinglePhase(t *testing.T) {
 
 func TestTotalDurationMultiplePhases(t *testing.T) {
 	timer := newTestTimer(30, 5)
-	timer.Get()            // "0s"
-	timer.AdvanceAndGet()  // "35s"
-	timer.AdvanceAndGet()  // "70s"
+	timer.Get()           // "0s"
+	timer.AdvanceAndGet() // "35s"
+	timer.AdvanceAndGet() // "70s"
 	if got := timer.TotalDuration(); got != "105s" {
 		t.Fatalf("TotalDuration() = %q, want %q", got, "105s")
 	}


### PR DESCRIPTION
## Summary
- gofmt `backends.go`, `metrics/results.go`, `timer_test.go`
- Check `scenarios.Set` return value in `AddDockerMetricsCollector` (errcheck)
- Trim trailing whitespace from `README.md`

These pre-existing issues are blocking CI on PR #45 (Dependabot go-deps bump). After this lands, comment `@dependabot rebase` on #45 to pick up green CI.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -l` clean on the three files