### PR TITLE
Feat/capture container info

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,24 @@ make
 
 ### 2. Start backends
 
-The included `docker-compose.yml` uses profiles, which provide an easy way to only spin up a subset of containers.
-
-Please note the 'sample' dataset which is included does not provide a meaningful benchmark, it's designed to show how to use the system.
+Each dataset under `datasets/` ships with its own `docker-compose.yml` that pins
+the exact images and tuning used for that benchmark. Run compose from the
+dataset directory so the captured `Container` tab in the dashboard reflects the
+real configuration:
 
 ```bash
-docker compose --profile paradedb --profile postgres up -d
+docker compose -f datasets/sample/docker-compose.yml up -d
 ```
+
+The repo-root `docker-compose.yml` is a kitchen-sink template containing every
+supported backend with profiles; it's intended as a starting point when
+authoring a new dataset, not for running an existing one.
+
+For backends running off-host (e.g. AWS RDS, managed Elasticsearch), pass
+`{ type: "paradedb", container: "" }` in the backend config to skip docker
+metrics for that backend.
+
+Please note the 'sample' dataset which is included does not provide a meaningful benchmark, it's designed to show how to use the system.
 
 See [Docker Setup](docs/docker.md) for all available profiles and services.
 

--- a/backends.go
+++ b/backends.go
@@ -3,6 +3,8 @@ package search
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/grafana/sobek"
@@ -64,6 +66,20 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 	datasetPath := parseDatasetPath(config, m.vu)
 	defaults := backends.DefaultConnections()
 	defaultContainers := backends.DefaultContainers()
+
+	// Capture dataset.yaml (written by `loader pull`) if present.
+	if datasetPath != "" {
+		if data, err := os.ReadFile(filepath.Join(datasetPath, "dataset.yaml")); err == nil {
+			metrics.RegisterRunCapture("dataset_yaml", string(data))
+		}
+	}
+
+	// Capture the running k6 script's source. k6 is invoked as
+	// `./k6 run [flags] <script.js>` — the script path is in os.Args.
+	if src, path := readRunningScript(); src != "" {
+		metrics.RegisterRunCapture("script", src)
+		metrics.RegisterRunCapture("script_path", path)
+	}
 
 	// Parse backends array
 	backendsArray, ok := config["backends"].([]interface{})
@@ -248,6 +264,37 @@ func (b *Backends) SetTimeout(seconds int) {
 	for _, client := range b.clients {
 		client.SetTimeout(seconds)
 	}
+}
+
+// readRunningScript locates the currently-running k6 script via os.Args and
+// returns its source text plus absolute path. The xk6 extension runs inside
+// the k6 process so the script path is reachable from argv directly; k6's
+// public extension API doesn't expose it as cleanly. Returns ("", "") if no
+// candidate is found.
+func readRunningScript() (source, path string) {
+	for _, arg := range os.Args[1:] {
+		if !looksLikeScript(arg) {
+			continue
+		}
+		abs, err := filepath.Abs(arg)
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			continue
+		}
+		return string(data), abs
+	}
+	return "", ""
+}
+
+func looksLikeScript(arg string) bool {
+	switch filepath.Ext(arg) {
+	case ".js", ".ts", ".mjs", ".cjs":
+		return true
+	}
+	return false
 }
 
 // parseDatasetPath extracts dataset path from config.

--- a/backends.go
+++ b/backends.go
@@ -74,6 +74,10 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 
 	for _, item := range backendsArray {
 		var backendType, alias, container, color, conn string
+		// containerExplicit tracks whether the user set the container field at all
+		// (including to ""). An explicit empty string opts the backend out of
+		// docker metrics — used for off-host services like AWS RDS.
+		var containerExplicit bool
 
 		switch v := item.(type) {
 		case string:
@@ -92,8 +96,11 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 			if a, ok := v["alias"].(string); ok {
 				alias = a
 			}
-			if c, ok := v["container"].(string); ok {
-				container = c
+			if raw, ok := v["container"]; ok {
+				containerExplicit = true
+				if c, ok := raw.(string); ok {
+					container = c
+				}
 			}
 			if c, ok := v["color"].(string); ok {
 				color = c
@@ -118,7 +125,9 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 		if conn == "" {
 			conn = defaults[backendType]
 		}
-		if container == "" {
+		// Only default the container name if the user didn't explicitly set it.
+		// An explicit "" opts out of docker capture (off-host backends).
+		if !containerExplicit {
 			if alias != backendType {
 				container = alias // default container to alias if alias is set
 			} else {
@@ -147,7 +156,9 @@ func (m *ModuleInstance) newBackends(config map[string]interface{}) *Backends {
 
 		client := backends.NewK6Client(m.vu, driver, alias)
 		b.clients[alias] = client
-		enabledContainers = append(enabledContainers, container)
+		if container != "" {
+			enabledContainers = append(enabledContainers, container)
+		}
 
 		driver.CaptureConfig(ctx, alias)
 		metrics.CapturePrePostScripts(alias, backendType, datasetPath, backendCfg.FileType)

--- a/cmd/loader/main.go
+++ b/cmd/loader/main.go
@@ -363,6 +363,7 @@ func runPull(datasetName, sourceURL string, anonymous bool) {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
+		writeDatasetManifest(destDir, sourceURL)
 		return
 	}
 
@@ -452,6 +453,23 @@ func runPull(datasetName, sourceURL string, anonymous bool) {
 	if failed > 0 {
 		os.Exit(1)
 	}
+	writeDatasetManifest(destDir, sourceURL)
+}
+
+// writeDatasetManifest records where the dataset was pulled from. The k6
+// extension reads this file at run time and embeds it in the dashboard JSON
+// so the run record carries the canonical S3 location.
+func writeDatasetManifest(destDir, sourceURL string) {
+	manifest := fmt.Sprintf("s3: %s\npulled_at: %s\n",
+		sourceURL,
+		time.Now().UTC().Format(time.RFC3339),
+	)
+	path := filepath.Join(destDir, "dataset.yaml")
+	if err := os.WriteFile(path, []byte(manifest), 0644); err != nil {
+		fmt.Printf("Warning: failed to write %s: %v\n", path, err)
+		return
+	}
+	fmt.Printf("Wrote %s\n", path)
 }
 
 // prepareDestDir ensures destDir is a real, empty directory we can safely

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -709,23 +709,18 @@ func (o *Output) getSummary() map[string]interface{} {
 			}
 		}
 
-		// Add database config based on backend tag
-		config, containerLimits := getBackendConfig(rm.Backend, rm.Container)
-
 		runs[name] = map[string]interface{}{
-			"name":            rm.Name,
-			"backend":         rm.Backend,
-			"container":       rm.Container,
-			"alias":           rm.Alias,
-			"color":           rm.Color,
-			"chart":           rm.Chart,
-			"ingestRate":      rm.IngestRate,
-			"totalIngested":   rm.TotalIngested,
-			"avgIngestRate":   ingestRate,
-			"queries":         queries,
-			"startTime":       rm.StartTime,
-			"config":          config,
-			"containerLimits": containerLimits,
+			"name":          rm.Name,
+			"backend":       rm.Backend,
+			"container":     rm.Container,
+			"alias":         rm.Alias,
+			"color":         rm.Color,
+			"chart":         rm.Chart,
+			"ingestRate":    rm.IngestRate,
+			"totalIngested": rm.TotalIngested,
+			"avgIngestRate": ingestRate,
+			"queries":       queries,
+			"startTime":     rm.StartTime,
 		}
 	}
 
@@ -742,15 +737,20 @@ func (o *Output) getSummary() map[string]interface{} {
 		}
 	}
 
-	return map[string]interface{}{
+	out := map[string]interface{}{
 		"elapsed":           elapsed,
 		"chartDuration":     chartDuration,
 		"runs":              runs,
+		"backends":          buildBackendsBlock(),
 		"containers":        containers,
 		"startTime":         o.data.StartTime.UnixMilli(),
 		"broadcastInterval": o.broadcastInterval.Milliseconds(),
 		"timelineWindow":    o.timelineWindow.Milliseconds(),
 	}
+	if meta := readMetaEnv(); meta != nil {
+		out["meta"] = meta
+	}
+	return out
 }
 
 // getExportData returns raw data for JSON export — no pre-aggregated timeline,
@@ -775,8 +775,6 @@ func (o *Output) getExportData() map[string]interface{} {
 			}
 		}
 
-		config, containerLimits := getBackendConfig(rm.Backend, rm.Container)
-
 		var endTime int64
 		if rm.EndTime > 0 {
 			endTime = rm.EndTime
@@ -787,19 +785,17 @@ func (o *Output) getExportData() map[string]interface{} {
 		}
 
 		runs[name] = map[string]interface{}{
-			"name":            rm.Name,
-			"backend":         rm.Backend,
-			"container":       rm.Container,
-			"alias":           rm.Alias,
-			"color":           rm.Color,
-			"chart":           rm.Chart,
-			"ingestRate":      rm.IngestRate,
-			"totalIngested":   rm.TotalIngested,
-			"startTime":       rm.StartTime,
-			"endTime":         endTime,
-			"config":          config,
-			"containerLimits": containerLimits,
-			"queries":         queries,
+			"name":          rm.Name,
+			"backend":       rm.Backend,
+			"container":     rm.Container,
+			"alias":         rm.Alias,
+			"color":         rm.Color,
+			"chart":         rm.Chart,
+			"ingestRate":    rm.IngestRate,
+			"totalIngested": rm.TotalIngested,
+			"startTime":     rm.StartTime,
+			"endTime":       endTime,
+			"queries":       queries,
 		}
 	}
 
@@ -815,11 +811,16 @@ func (o *Output) getExportData() map[string]interface{} {
 		}
 	}
 
-	return map[string]interface{}{
+	out := map[string]interface{}{
 		"startTime":  o.data.StartTime.UnixMilli(),
 		"runs":       runs,
+		"backends":   buildBackendsBlock(),
 		"containers": containers,
 	}
+	if meta := readMetaEnv(); meta != nil {
+		out["meta"] = meta
+	}
+	return out
 }
 
 // aggregateExportData takes raw export JSON (with latencies/timestamps per query)
@@ -1142,19 +1143,52 @@ func getQueryPattern(backend, chart, qName string) string {
 	return metrics.GetQueryPattern(backend, chart, qName)
 }
 
-// getBackendConfig returns the database config and container limits for a backend type.
-// Container limits are looked up by container name, not backend name.
-func getBackendConfig(backend, container string) (map[string]interface{}, map[string]interface{}) {
-	if backend == "" {
-		return nil, nil
+// buildBackendsBlock returns the deduplicated per-backend snapshot for the
+// dashboard JSON. Each entry combines the backend's database config (postgres
+// GUCs, version, pre/post scripts), the docker-inspect data for its container,
+// and display options (alias, color). The frontend looks up by backend alias.
+func buildBackendsBlock() map[string]interface{} {
+	options := metrics.GetAllBackendOptions()
+	backends := make(map[string]interface{}, len(options))
+	for alias, opt := range options {
+		entry := map[string]interface{}{
+			"alias":     opt.Alias,
+			"container": opt.Container,
+			"color":     opt.Color,
+		}
+		if cfg := metrics.GetBackendConfig(alias); cfg != nil {
+			entry["config"] = cfg
+		}
+		if opt.Container != "" {
+			if info := metrics.GetContainerInfo(opt.Container); info != nil {
+				entry["container_info"] = info
+			}
+		}
+		backends[alias] = entry
 	}
-	// Look up limits by container name (which may be alias or custom container name)
-	limits := metrics.GetContainerLimits(container)
-	if limits == nil && container != backend {
-		// Fall back to backend name for backwards compatibility
-		limits = metrics.GetContainerLimits(backend)
+	return backends
+}
+
+// readMetaEnv returns the parsed BENCHMARKER_META env var, or nil if unset.
+// Supports either inline JSON ('{"commit":"abc"}') or '@path/to/file.json'.
+func readMetaEnv() map[string]interface{} {
+	raw := os.Getenv("BENCHMARKER_META")
+	if raw == "" {
+		return nil
 	}
-	return metrics.GetBackendConfig(backend), limits
+	data := []byte(raw)
+	if strings.HasPrefix(raw, "@") {
+		b, err := os.ReadFile(raw[1:])
+		if err != nil {
+			return nil
+		}
+		data = b
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil
+	}
+	return m
 }
 
 // ServeFile starts a server to view a saved dashboard JSON file.

--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -750,6 +750,7 @@ func (o *Output) getSummary() map[string]interface{} {
 	if meta := readMetaEnv(); meta != nil {
 		out["meta"] = meta
 	}
+	addRunCaptures(out)
 	return out
 }
 
@@ -820,6 +821,7 @@ func (o *Output) getExportData() map[string]interface{} {
 	if meta := readMetaEnv(); meta != nil {
 		out["meta"] = meta
 	}
+	addRunCaptures(out)
 	return out
 }
 
@@ -1167,6 +1169,21 @@ func buildBackendsBlock() map[string]interface{} {
 		backends[alias] = entry
 	}
 	return backends
+}
+
+// addRunCaptures stamps any registered run-level captures (dataset.yaml text,
+// k6 script source) onto the given dashboard output map under top-level keys.
+// Absent captures are not stamped — the frontend hides their tabs.
+func addRunCaptures(out map[string]interface{}) {
+	if s := metrics.GetRunCapture("dataset_yaml"); s != "" {
+		out["dataset_yaml"] = s
+	}
+	if s := metrics.GetRunCapture("script"); s != "" {
+		out["script"] = s
+	}
+	if s := metrics.GetRunCapture("script_path"); s != "" {
+		out["script_path"] = s
+	}
 }
 
 // readMetaEnv returns the parsed BENCHMARKER_META env var, or nil if unset.

--- a/dashboard/output_test.go
+++ b/dashboard/output_test.go
@@ -2,8 +2,12 @@ package dashboard
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/paradedb/benchmarker/metrics"
 )
 
 func TestUpdateIngestRateSkipsInitialPoint(t *testing.T) {
@@ -87,5 +91,95 @@ func TestGetSummaryUsesQueryWindowForQPS(t *testing.T) {
 	got := query["qps"].(float64)
 	if math.Abs(got-2.0) > 0.001 {
 		t.Fatalf("expected query qps of 2.0, got %.3f", got)
+	}
+}
+
+func TestGetSummaryEmitsTopLevelBackendsBlock(t *testing.T) {
+	metrics.RegisterBackendOptions("paradedb", &metrics.BackendOptions{
+		Container: "paradedb",
+		Alias:     "paradedb",
+		Color:     "#7c3aed",
+	})
+	metrics.RegisterBackendConfig("paradedb", map[string]interface{}{
+		"version": "PostgreSQL 18.0",
+	})
+	t.Cleanup(func() {
+		metrics.RegisterBackendConfig("paradedb", nil)
+	})
+
+	o := &Output{
+		data: &DashboardData{
+			StartTime: time.Unix(0, 0),
+			Runs: map[string]*RunMetrics{
+				"paradedb_simple": {
+					Name:    "paradedb_simple",
+					Backend: "paradedb",
+					Queries: map[string]*QueryMetrics{},
+				},
+			},
+		},
+	}
+
+	summary := o.getSummary()
+
+	// Top-level backends block exists and carries the deduplicated config.
+	backends, ok := summary["backends"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level backends block, got %T", summary["backends"])
+	}
+	paradedb, ok := backends["paradedb"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected backends[paradedb], got %T", backends["paradedb"])
+	}
+	cfg, ok := paradedb["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected backends[paradedb].config map")
+	}
+	if cfg["version"] != "PostgreSQL 18.0" {
+		t.Fatalf("expected version in config, got %v", cfg["version"])
+	}
+
+	// Per-run entries no longer carry config / containerLimits.
+	run := summary["runs"].(map[string]interface{})["paradedb_simple"].(map[string]interface{})
+	if _, present := run["config"]; present {
+		t.Fatalf("expected run.config to be stripped (now top-level)")
+	}
+	if _, present := run["containerLimits"]; present {
+		t.Fatalf("expected run.containerLimits to be stripped (now under container_info)")
+	}
+}
+
+func TestReadMetaEnvInline(t *testing.T) {
+	t.Setenv("BENCHMARKER_META", `{"commit":"abc123","version":"v0.23.1"}`)
+	m := readMetaEnv()
+	if m["commit"] != "abc123" {
+		t.Fatalf("expected commit=abc123, got %v", m["commit"])
+	}
+	if m["version"] != "v0.23.1" {
+		t.Fatalf("expected version=v0.23.1, got %v", m["version"])
+	}
+}
+
+func TestReadMetaEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.json")
+	if err := os.WriteFile(path, []byte(`{"commit":"xyz","links":["https://example.com"]}`), 0644); err != nil {
+		t.Fatalf("write meta file: %v", err)
+	}
+	t.Setenv("BENCHMARKER_META", "@"+path)
+	m := readMetaEnv()
+	if m["commit"] != "xyz" {
+		t.Fatalf("expected commit=xyz, got %v", m["commit"])
+	}
+	links, ok := m["links"].([]interface{})
+	if !ok || len(links) != 1 || links[0] != "https://example.com" {
+		t.Fatalf("expected links=[example.com], got %v", m["links"])
+	}
+}
+
+func TestReadMetaEnvUnsetReturnsNil(t *testing.T) {
+	t.Setenv("BENCHMARKER_META", "")
+	if m := readMetaEnv(); m != nil {
+		t.Fatalf("expected nil for unset env, got %v", m)
 	}
 }

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1344,6 +1344,7 @@
               return getAvgMetric(runA) - getAvgMetric(runB);
             });
 
+            const backendsBlock = data.backends || {};
             sortedBackends.forEach((name, idx) => {
               const run = runs[name];
               const color = getRunColor(name, run);
@@ -1351,9 +1352,12 @@
               const statId = `stat-${safeNameId}`;
               const queryContainerId = `${safeNameId}-queries`;
 
-              // Store config if available
-              if (run.config && Object.keys(run.config).length > 0) {
-                runConfigs[name] = run.config;
+              // Look up the deduplicated backend snapshot for this run.
+              const backendSnapshot = backendsBlock[run.backend] || {};
+              const backendConfig = backendSnapshot.config || {};
+              const containerInfo = backendSnapshot.container_info || null;
+              if (Object.keys(backendConfig).length > 0 || containerInfo) {
+                runConfigs[name] = backendSnapshot;
               }
 
               const labelId = `label-${safeNameId}`;
@@ -1365,14 +1369,14 @@
                 el.className = "stat-group expanded";
                 el.style.borderLeftColor = color;
 
-                // Build limits string
+                // Build limits string from container_info on the backend snapshot.
                 let limitsStr = "";
-                if (run.containerLimits) {
+                if (containerInfo) {
                   const parts = [];
-                  if (run.containerLimits.cpu_limit)
-                    parts.push(escapeHtml(run.containerLimits.cpu_limit));
-                  if (run.containerLimits.memory_limit)
-                    parts.push(escapeHtml(run.containerLimits.memory_limit));
+                  if (containerInfo.cpu_limit)
+                    parts.push(escapeHtml(containerInfo.cpu_limit));
+                  if (containerInfo.memory_limit)
+                    parts.push(escapeHtml(containerInfo.memory_limit));
                   if (parts.length > 0)
                     limitsStr = `<span style="color: var(--text-dim); font-size: 9px; margin-left: 8px;">${parts.join(" / ")}</span>`;
                 }
@@ -1388,7 +1392,8 @@
 
               // Set up config click handler after element is in the DOM.
               // Runs on every update so it works even if config arrives later.
-              const hasConfig = run.config && Object.keys(run.config).length > 0;
+              const hasConfig =
+                Object.keys(backendConfig).length > 0 || containerInfo;
               if (hasConfig) {
                 const labelEl = document.getElementById(labelId);
                 if (labelEl && !labelEl.dataset.configHandler) {
@@ -1618,18 +1623,17 @@
       }
 
       function showConfigModal(runName) {
-        const config = runConfigs[runName];
-        if (!config || Object.keys(config).length === 0) {
-          return; // No config available
-        }
+        const snapshot = runConfigs[runName];
+        if (!snapshot) return;
+        const config = snapshot.config || {};
+        const containerInfo = snapshot.container_info || null;
+        if (Object.keys(config).length === 0 && !containerInfo) return;
 
         document.getElementById("config-modal-title").textContent = runName;
 
-        // Separate config into tabs
         const preScript = config.pre_script;
         const postScript = config.post_script;
 
-        // Build tabs
         let tabsHtml = '<div class="config-tabs">';
         tabsHtml +=
           '<button class="config-tab active" onclick="switchConfigTab(\'config\')">Config</button>';
@@ -1641,20 +1645,22 @@
           tabsHtml +=
             '<button class="config-tab" onclick="switchConfigTab(\'post\')">Post</button>';
         }
+        if (containerInfo) {
+          tabsHtml +=
+            '<button class="config-tab" onclick="switchConfigTab(\'container\')">Container</button>';
+        }
         tabsHtml += "</div>";
 
-        // Helper to format config values
         function formatConfigValue(val) {
           if (val === null || val === undefined) return "-";
           if (typeof val === "object") return JSON.stringify(val);
           return String(val);
         }
 
-        // Config tab content
+        // Config tab — DB GUCs etc.
         let configHtml =
           '<div id="tab-config" class="config-tab-content active">';
         for (const [section, value] of Object.entries(config)) {
-          // Skip sections that have their own tabs
           if (["pre_script", "post_script"].includes(section)) continue;
 
           if (
@@ -1680,24 +1686,130 @@
         }
         configHtml += "</div>";
 
-        // Pre script tab content
+        // Pre / Post tabs.
+        const codeBlock = (text) =>
+          `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0; background: var(--bg); padding: 12px; border-radius: 4px;">${escapeHtml(text)}</pre>`;
         let preHtml = '<div id="tab-pre" class="config-tab-content">';
-        if (preScript) {
-          preHtml += `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0; background: var(--bg); padding: 12px; border-radius: 4px;">${escapeHtml(preScript)}</pre>`;
-        }
+        if (preScript) preHtml += codeBlock(preScript);
         preHtml += "</div>";
 
-        // Post script tab content
         let postHtml = '<div id="tab-post" class="config-tab-content">';
-        if (postScript) {
-          postHtml += `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0; background: var(--bg); padding: 12px; border-radius: 4px;">${escapeHtml(postScript)}</pre>`;
-        }
+        if (postScript) postHtml += codeBlock(postScript);
         postHtml += "</div>";
 
+        // Container tab — docker inspect subset.
+        let containerHtml = '<div id="tab-container" class="config-tab-content">';
+        if (containerInfo) {
+          containerHtml += renderContainerInfo(containerInfo);
+        }
+        containerHtml += "</div>";
+
         document.getElementById("config-modal-content").innerHTML =
-          tabsHtml + configHtml + preHtml + postHtml;
+          tabsHtml + configHtml + preHtml + postHtml + containerHtml;
         document.getElementById("modal-backdrop").classList.add("visible");
         document.getElementById("config-modal").classList.add("visible");
+      }
+
+      // renderContainerInfo turns the docker-inspect subset into the same
+      // sections/items layout used by the Config tab.
+      function renderContainerInfo(info) {
+        const items = (kvs) =>
+          kvs
+            .map(
+              ([k, v]) =>
+                `<div class="config-item">
+                  <span class="config-key">${escapeHtml(k)}</span>
+                  <span class="config-value">${escapeHtml(v)}</span>
+                </div>`,
+            )
+            .join("");
+        const section = (title, body) =>
+          `<div class="config-section">
+            <div class="config-section-title">${escapeHtml(title)}</div>
+            ${body}
+          </div>`;
+
+        let html = "";
+
+        // Image + identity
+        const idRows = [];
+        if (info.image) idRows.push(["image", info.image]);
+        if (info.image_id) idRows.push(["image_id", info.image_id]);
+        if (info.network_mode) idRows.push(["network_mode", info.network_mode]);
+        if (info.cpu_limit) idRows.push(["cpu_limit", info.cpu_limit]);
+        if (info.memory_limit) idRows.push(["memory_limit", info.memory_limit]);
+        if (idRows.length) html += section("identity", items(idRows));
+
+        // Command
+        if (Array.isArray(info.cmd) && info.cmd.length) {
+          html +=
+            section(
+              "cmd",
+              `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0;">${escapeHtml(info.cmd.join(" "))}</pre>`,
+            );
+        }
+
+        // Env
+        if (Array.isArray(info.env) && info.env.length) {
+          html += section(
+            "env",
+            items(
+              info.env.map((e) => {
+                const idx = e.indexOf("=");
+                return idx >= 0
+                  ? [e.slice(0, idx), e.slice(idx + 1)]
+                  : [e, ""];
+              }),
+            ),
+          );
+        }
+
+        // Host config raw fields
+        if (info.host_config) {
+          const hc = info.host_config;
+          const rows = [];
+          if (hc.nano_cpus) rows.push(["nano_cpus", String(hc.nano_cpus)]);
+          if (hc.memory) rows.push(["memory", String(hc.memory)]);
+          if (hc.cpu_quota) rows.push(["cpu_quota", String(hc.cpu_quota)]);
+          if (Array.isArray(hc.cap_add) && hc.cap_add.length)
+            rows.push(["cap_add", hc.cap_add.join(", ")]);
+          if (Array.isArray(hc.security_opt) && hc.security_opt.length)
+            rows.push(["security_opt", hc.security_opt.join(", ")]);
+          if (rows.length) html += section("host_config", items(rows));
+        }
+
+        // Mounts
+        if (Array.isArray(info.mounts) && info.mounts.length) {
+          const rows = info.mounts.map((m) => [
+            m.destination || "?",
+            `${m.type || ""} ${m.source || ""}${m.rw === false ? " (ro)" : ""}`.trim(),
+          ]);
+          html += section("mounts", items(rows));
+        }
+
+        // Ports
+        if (info.ports && Object.keys(info.ports).length) {
+          const rows = [];
+          for (const [containerPort, bindings] of Object.entries(info.ports)) {
+            const value = Array.isArray(bindings)
+              ? bindings
+                  .map((b) => `${b.host_ip || "0.0.0.0"}:${b.host_port || ""}`)
+                  .join(", ")
+              : "";
+            rows.push([containerPort, value]);
+          }
+          html += section("ports", items(rows));
+        }
+
+        // Labels
+        if (info.labels && Object.keys(info.labels).length) {
+          html += section(
+            "labels",
+            items(Object.entries(info.labels).map(([k, v]) => [k, String(v)])),
+          );
+        }
+
+        return html;
       }
 
       function switchConfigTab(tabName) {

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1285,7 +1285,8 @@
         );
       }
 
-      function updateStats(runs) {
+      function updateStats(runs, backendsBlock) {
+        backendsBlock = backendsBlock || {};
         // Group runs by chart (show runs with queries even before timeline data)
         const runsByChart = {};
         Object.keys(runs)
@@ -1344,7 +1345,6 @@
               return getAvgMetric(runA) - getAvgMetric(runB);
             });
 
-            const backendsBlock = data.backends || {};
             sortedBackends.forEach((name, idx) => {
               const run = runs[name];
               const color = getRunColor(name, run);
@@ -1356,9 +1356,7 @@
               const backendSnapshot = backendsBlock[run.backend] || {};
               const backendConfig = backendSnapshot.config || {};
               const containerInfo = backendSnapshot.container_info || null;
-              if (Object.keys(backendConfig).length > 0 || containerInfo) {
-                runConfigs[name] = backendSnapshot;
-              }
+              runConfigs[name] = backendSnapshot;
 
               const labelId = `label-${safeNameId}`;
               let el = document.getElementById(statId);
@@ -1392,8 +1390,12 @@
 
               // Set up config click handler after element is in the DOM.
               // Runs on every update so it works even if config arrives later.
+              const hasGlobalCapture =
+                (lastData && (lastData.dataset_yaml || lastData.script)) || false;
               const hasConfig =
-                Object.keys(backendConfig).length > 0 || containerInfo;
+                Object.keys(backendConfig).length > 0 ||
+                containerInfo ||
+                hasGlobalCapture;
               if (hasConfig) {
                 const labelEl = document.getElementById(labelId);
                 if (labelEl && !labelEl.dataset.configHandler) {
@@ -1623,11 +1625,18 @@
       }
 
       function showConfigModal(runName) {
-        const snapshot = runConfigs[runName];
-        if (!snapshot) return;
+        const snapshot = runConfigs[runName] || {};
         const config = snapshot.config || {};
         const containerInfo = snapshot.container_info || null;
-        if (Object.keys(config).length === 0 && !containerInfo) return;
+        const hasGlobalCapture =
+          (lastData && (lastData.dataset_yaml || lastData.script)) || false;
+        if (
+          Object.keys(config).length === 0 &&
+          !containerInfo &&
+          !hasGlobalCapture
+        ) {
+          return;
+        }
 
         document.getElementById("config-modal-title").textContent = runName;
 
@@ -1648,6 +1657,16 @@
         if (containerInfo) {
           tabsHtml +=
             '<button class="config-tab" onclick="switchConfigTab(\'container\')">Container</button>';
+        }
+        const datasetYaml = (lastData && lastData.dataset_yaml) || "";
+        const scriptSource = (lastData && lastData.script) || "";
+        if (datasetYaml) {
+          tabsHtml +=
+            '<button class="config-tab" onclick="switchConfigTab(\'dataset\')">Dataset</button>';
+        }
+        if (scriptSource) {
+          tabsHtml +=
+            '<button class="config-tab" onclick="switchConfigTab(\'script\')">Script</button>';
         }
         tabsHtml += "</div>";
 
@@ -1704,8 +1723,18 @@
         }
         containerHtml += "</div>";
 
+        // Dataset / Script tabs — global to the run, hidden when absent.
+        const sourceBlock = (text) =>
+          `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0; background: var(--bg); padding: 12px; border-radius: 4px;">${escapeHtml(text)}</pre>`;
+        let datasetHtml = '<div id="tab-dataset" class="config-tab-content">';
+        if (datasetYaml) datasetHtml += sourceBlock(datasetYaml);
+        datasetHtml += "</div>";
+        let scriptHtml = '<div id="tab-script" class="config-tab-content">';
+        if (scriptSource) scriptHtml += sourceBlock(scriptSource);
+        scriptHtml += "</div>";
+
         document.getElementById("config-modal-content").innerHTML =
-          tabsHtml + configHtml + preHtml + postHtml + containerHtml;
+          tabsHtml + configHtml + preHtml + postHtml + containerHtml + datasetHtml + scriptHtml;
         document.getElementById("modal-backdrop").classList.add("visible");
         document.getElementById("config-modal").classList.add("visible");
       }
@@ -1731,25 +1760,24 @@
 
         let html = "";
 
-        // Image + identity
         const idRows = [];
         if (info.image) idRows.push(["image", info.image]);
         if (info.image_id) idRows.push(["image_id", info.image_id]);
-        if (info.network_mode) idRows.push(["network_mode", info.network_mode]);
         if (info.cpu_limit) idRows.push(["cpu_limit", info.cpu_limit]);
         if (info.memory_limit) idRows.push(["memory_limit", info.memory_limit]);
+        if (Array.isArray(info.cap_add) && info.cap_add.length)
+          idRows.push(["cap_add", info.cap_add.join(", ")]);
+        if (Array.isArray(info.security_opt) && info.security_opt.length)
+          idRows.push(["security_opt", info.security_opt.join(", ")]);
         if (idRows.length) html += section("identity", items(idRows));
 
-        // Command
         if (Array.isArray(info.cmd) && info.cmd.length) {
-          html +=
-            section(
-              "cmd",
-              `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0;">${escapeHtml(info.cmd.join(" "))}</pre>`,
-            );
+          html += section(
+            "cmd",
+            `<pre style="white-space: pre-wrap; word-break: break-word; font-size: 10px; margin: 0;">${escapeHtml(info.cmd.join(" "))}</pre>`,
+          );
         }
 
-        // Env
         if (Array.isArray(info.env) && info.env.length) {
           html += section(
             "env",
@@ -1761,51 +1789,6 @@
                   : [e, ""];
               }),
             ),
-          );
-        }
-
-        // Host config raw fields
-        if (info.host_config) {
-          const hc = info.host_config;
-          const rows = [];
-          if (hc.nano_cpus) rows.push(["nano_cpus", String(hc.nano_cpus)]);
-          if (hc.memory) rows.push(["memory", String(hc.memory)]);
-          if (hc.cpu_quota) rows.push(["cpu_quota", String(hc.cpu_quota)]);
-          if (Array.isArray(hc.cap_add) && hc.cap_add.length)
-            rows.push(["cap_add", hc.cap_add.join(", ")]);
-          if (Array.isArray(hc.security_opt) && hc.security_opt.length)
-            rows.push(["security_opt", hc.security_opt.join(", ")]);
-          if (rows.length) html += section("host_config", items(rows));
-        }
-
-        // Mounts
-        if (Array.isArray(info.mounts) && info.mounts.length) {
-          const rows = info.mounts.map((m) => [
-            m.destination || "?",
-            `${m.type || ""} ${m.source || ""}${m.rw === false ? " (ro)" : ""}`.trim(),
-          ]);
-          html += section("mounts", items(rows));
-        }
-
-        // Ports
-        if (info.ports && Object.keys(info.ports).length) {
-          const rows = [];
-          for (const [containerPort, bindings] of Object.entries(info.ports)) {
-            const value = Array.isArray(bindings)
-              ? bindings
-                  .map((b) => `${b.host_ip || "0.0.0.0"}:${b.host_port || ""}`)
-                  .join(", ")
-              : "";
-            rows.push([containerPort, value]);
-          }
-          html += section("ports", items(rows));
-        }
-
-        // Labels
-        if (info.labels && Object.keys(info.labels).length) {
-          html += section(
-            "labels",
-            items(Object.entries(info.labels).map(([k, v]) => [k, String(v)])),
           );
         }
 
@@ -1920,7 +1903,7 @@
           .sort();
 
         updateQueryFilters(runs); // Initialize selected queries first
-        updateStats(runs);
+        updateStats(runs, data.backends);
         updateLegend(runs);
 
         // Group runs by chart and track earliest start time per chart

--- a/datasets/sample/docker-compose.yml
+++ b/datasets/sample/docker-compose.yml
@@ -1,0 +1,160 @@
+services:
+  paradedb:
+    image: paradedb/paradedb:v0.23.1-pg18
+    container_name: paradedb
+    privileged: true
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - seccomp:unconfined
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: benchmark
+    ports:
+      - "5432:5432"
+    volumes:
+      - paradedb_data:/var/lib/postgresql/18/docker
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
+        reservations:
+          cpus: "2"
+          memory: 4G
+    cpus: 4
+    mem_limit: 8g
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_search"
+      - "-c"
+      - "shared_buffers=2GB"
+      - "-c"
+      - "effective_cache_size=4GB"
+      - "-c"
+      - "work_mem=256MB"
+      - "-c"
+      - "maintenance_work_mem=1GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "wal_buffers=256MB"
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_workers=2"
+      - "-c"
+      - "max_worker_processes=16"
+      - "-c"
+      - "jit=off"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=50"
+      - bootstrap.memory_lock=true
+      - thread_pool.search.size=4
+      - thread_pool.search.queue_size=2000
+      - thread_pool.write.size=4
+      - indices.memory.index_buffer_size=20%
+      - indices.queries.cache.size=20%
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
+        reservations:
+          cpus: "2"
+          memory: 4G
+    cpus: 4
+    mem_limit: 8g
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.12
+    container_name: clickhouse
+    environment:
+      - CLICKHOUSE_DB=benchmark
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=clickhouse
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
+        reservations:
+          cpus: "2"
+          memory: 4G
+    cpus: 4
+    mem_limit: 8g
+
+  mongodb:
+    image: mongodb/mongodb-atlas-local
+    container_name: mongodb
+    environment:
+      - DO_NOT_TRACK=1
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
+        reservations:
+          cpus: "2"
+          memory: 4G
+    cpus: 4
+    mem_limit: 8g
+
+volumes:
+  paradedb_data:
+  elasticsearch_data:
+  clickhouse_data:
+  mongodb_data:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -10,7 +10,28 @@ The real-time dashboard streams benchmark results to a browser-based UI as the t
 - **Container resources** - CPU and memory usage from Docker
 - **Backend configuration** - Database settings and version info
 - **Pre/Post scripts** - Full SQL/JSON scripts used for setup (for reproducibility)
+- **Container** - Curated `docker inspect` output (image, command, env, mounts, ports, host config) for each backend container, captured at run start
 - **Query patterns** - Actual queries executed per scenario
+
+## Run metadata
+
+Stamp arbitrary metadata into the exported JSON via the `BENCHMARKER_META` env
+var. It's written verbatim to a top-level `meta` field — useful for the
+commit / version / machine / link details that aren't observable from the
+running stack:
+
+```bash
+# Inline JSON
+BENCHMARKER_META='{"commit":"abc123","version":"v0.23.1"}' \
+  ./k6 run --out dashboard script.js
+
+# Or from a file
+BENCHMARKER_META=@./run-meta.json \
+  ./k6 run --out dashboard script.js
+```
+
+The dashboard frontend doesn't render `meta` directly today — it's there for
+downstream consumers (publishing tooling, reports) to read out of the JSON.
 
 ## Usage
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,6 +2,36 @@
 
 Docker is **optional**. You can run benchmarks against any database instance - local installs, cloud services, or remote servers. Without Docker, you lose container CPU/memory metrics in the dashboard, but everything else works.
 
+## Per-dataset compose (recommended)
+
+Each dataset under `datasets/` ships with its own `docker-compose.yml` that
+pins the exact images and tuning used for that benchmark. This is the
+recommended way to run a benchmark — the captured `Container` tab in the
+dashboard will reflect the real images/configuration used:
+
+```bash
+docker compose -f datasets/sample/docker-compose.yml up -d
+```
+
+## Repo-root template (kitchen sink)
+
+The repo-root `docker-compose.yml` is a kitchen-sink template containing every
+supported backend behind compose profiles. It's intended as a starting point
+when authoring a new dataset, not for running existing ones — copy the
+relevant services into a new `datasets/<name>/docker-compose.yml`.
+
+## Off-host backends
+
+When benchmarking against managed services or remote hosts (e.g. AWS RDS,
+managed Elasticsearch), there is no local container to inspect. Pass an empty
+`container` in the JS backend config to skip docker capture for that backend:
+
+```js
+const backends = db.backends({
+  backends: [{ type: "paradedb", container: "", connection: "postgres://..." }],
+});
+```
+
 ## Profiles
 
 Start backends individually or all at once using Docker Compose profiles:

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -35,7 +35,32 @@ var (
 	// Backend options (registered once at init - container, alias, color)
 	backendOptions   = make(map[string]*BackendOptions)
 	backendOptionsMu sync.RWMutex
+
+	// Per-run capture: dataset.yaml contents (if present) and the k6 script source.
+	// These are set once during db.backends() init and surfaced verbatim in the
+	// dashboard JSON. The frontend renders them as Dataset / Script tabs.
+	runCapture   = make(map[string]string)
+	runCaptureMu sync.RWMutex
 )
+
+// RegisterRunCapture stores a run-level text artifact (e.g. "dataset.yaml" or
+// "script.js") for later inclusion in the dashboard JSON. Empty values are
+// ignored — call with "" to leave the slot unset.
+func RegisterRunCapture(key, text string) {
+	if text == "" {
+		return
+	}
+	runCaptureMu.Lock()
+	defer runCaptureMu.Unlock()
+	runCapture[key] = text
+}
+
+// GetRunCapture returns the text registered under key, or "" if unset.
+func GetRunCapture(key string) string {
+	runCaptureMu.RLock()
+	defer runCaptureMu.RUnlock()
+	return runCapture[key]
+}
 
 // BackendOptions holds user-specified options for a backend.
 type BackendOptions struct {
@@ -404,10 +429,9 @@ func (c *Collector) fetchAndCalculateStats(container string) (*ContainerStats, e
 type dockerInspect struct {
 	Image  string `json:"Image"` // image SHA, e.g. "sha256:abc..."
 	Config struct {
-		Image  string            `json:"Image"` // image tag, e.g. "paradedb/paradedb:v0.23.1"
-		Cmd    []string          `json:"Cmd"`
-		Env    []string          `json:"Env"`
-		Labels map[string]string `json:"Labels"`
+		Image string   `json:"Image"` // image tag, e.g. "paradedb/paradedb:v0.23.1"
+		Cmd   []string `json:"Cmd"`
+		Env   []string `json:"Env"`
 	} `json:"Config"`
 	HostConfig struct {
 		NanoCPUs    int64    `json:"NanoCpus"`
@@ -415,21 +439,7 @@ type dockerInspect struct {
 		CPUQuota    int64    `json:"CpuQuota"`
 		CapAdd      []string `json:"CapAdd"`
 		SecurityOpt []string `json:"SecurityOpt"`
-		NetworkMode string   `json:"NetworkMode"`
 	} `json:"HostConfig"`
-	Mounts []struct {
-		Type        string `json:"Type"`
-		Source      string `json:"Source"`
-		Destination string `json:"Destination"`
-		Mode        string `json:"Mode"`
-		RW          bool   `json:"RW"`
-	} `json:"Mounts"`
-	NetworkSettings struct {
-		Ports map[string][]struct {
-			HostIP   string `json:"HostIp"`
-			HostPort string `json:"HostPort"`
-		} `json:"Ports"`
-	} `json:"NetworkSettings"`
 }
 
 // captureContainerInfo fetches the docker inspect output and stores a curated
@@ -462,17 +472,8 @@ func (c *Collector) captureContainerInfo(container string) bool {
 		"image_id":     inspect.Image,
 		"cmd":          inspect.Config.Cmd,
 		"env":          inspect.Config.Env,
-		"labels":       inspect.Config.Labels,
-		"mounts":       inspect.Mounts,
-		"network_mode": inspect.HostConfig.NetworkMode,
-		"ports":        inspect.NetworkSettings.Ports,
-		"host_config": map[string]interface{}{
-			"nano_cpus":    inspect.HostConfig.NanoCPUs,
-			"memory":       inspect.HostConfig.Memory,
-			"cpu_quota":    inspect.HostConfig.CPUQuota,
-			"cap_add":      inspect.HostConfig.CapAdd,
-			"security_opt": inspect.HostConfig.SecurityOpt,
-		},
+		"cap_add":      inspect.HostConfig.CapAdd,
+		"security_opt": inspect.HostConfig.SecurityOpt,
 	}
 
 	// Display-friendly limit strings for the existing UI.

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -23,10 +23,10 @@ var (
 	containerMemory *metrics.Metric
 	metricsOnce     sync.Once
 
-	// Container resource limits (captured once)
-	ContainerLimits   = make(map[string]map[string]interface{})
-	containerLimitsMu sync.RWMutex
-	limitsCapture     = make(map[string]bool)
+	// Captured docker-inspect data per container (captured once at first stats collection).
+	containerInfo   = make(map[string]map[string]interface{})
+	containerInfoMu sync.RWMutex
+	infoCapture     = make(map[string]bool)
 
 	// Backend configs (registered by each backend - database settings etc)
 	backendConfigs   = make(map[string]map[string]interface{})
@@ -67,21 +67,44 @@ func GetBackendConfig(backend string) map[string]interface{} {
 	return result
 }
 
-// GetContainerLimits returns captured container limits by container name.
-func GetContainerLimits(container string) map[string]interface{} {
-	containerLimitsMu.RLock()
-	defer containerLimitsMu.RUnlock()
+// GetContainerInfo returns the captured docker-inspect subset for a container.
+// The returned map contains keys like image, image_id, cmd, env, host_config,
+// mounts, labels, network_mode, ports, plus display-friendly cpu_limit and
+// memory_limit strings.
+func GetContainerInfo(container string) map[string]interface{} {
+	containerInfoMu.RLock()
+	defer containerInfoMu.RUnlock()
 
-	limits := ContainerLimits[container]
-	if limits == nil {
+	info := containerInfo[container]
+	if info == nil {
 		return nil
 	}
 
-	result := make(map[string]interface{}, len(limits))
-	for k, v := range limits {
+	result := make(map[string]interface{}, len(info))
+	for k, v := range info {
 		result[k] = v
 	}
 	return result
+}
+
+// GetContainerLimits returns just the CPU/memory limit strings from the captured
+// container info. Retained for legacy callers; new code should use GetContainerInfo.
+func GetContainerLimits(container string) map[string]interface{} {
+	info := GetContainerInfo(container)
+	if info == nil {
+		return nil
+	}
+	limits := make(map[string]interface{})
+	if v, ok := info["cpu_limit"]; ok {
+		limits["cpu_limit"] = v
+	}
+	if v, ok := info["memory_limit"]; ok {
+		limits["memory_limit"] = v
+	}
+	if len(limits) == 0 {
+		return nil
+	}
+	return limits
 }
 
 // CapturePrePostScripts reads pre/post scripts from the dataset directory
@@ -256,26 +279,26 @@ func (c *Collector) Collect() map[string]interface{} {
 	baseTags := state.Tags.GetCurrentValues()
 	results := make(map[string]interface{})
 
-	// Capture container limits once (in parallel)
-	var limitsWg sync.WaitGroup
+	// Capture docker inspect info once per container (in parallel).
+	var infoWg sync.WaitGroup
 	for _, container := range c.containers {
-		containerLimitsMu.Lock()
-		needsCapture := !limitsCapture[container]
-		containerLimitsMu.Unlock()
+		containerInfoMu.Lock()
+		needsCapture := !infoCapture[container]
+		containerInfoMu.Unlock()
 
 		if needsCapture {
-			limitsWg.Add(1)
+			infoWg.Add(1)
 			go func(cont string) {
-				defer limitsWg.Done()
-				if c.captureContainerLimits(cont) {
-					containerLimitsMu.Lock()
-					limitsCapture[cont] = true
-					containerLimitsMu.Unlock()
+				defer infoWg.Done()
+				if c.captureContainerInfo(cont) {
+					containerInfoMu.Lock()
+					infoCapture[cont] = true
+					containerInfoMu.Unlock()
 				}
 			}(container)
 		}
 	}
-	limitsWg.Wait()
+	infoWg.Wait()
 
 	// Fetch stats for all containers in parallel
 	resultChan := make(chan containerResult, len(c.containers))
@@ -377,16 +400,41 @@ func (c *Collector) fetchAndCalculateStats(container string) (*ContainerStats, e
 }
 
 // dockerInspect matches the Docker API inspect response (partial).
+// Only the subset needed for the dashboard's "Container" tab is decoded.
 type dockerInspect struct {
+	Image  string `json:"Image"` // image SHA, e.g. "sha256:abc..."
+	Config struct {
+		Image  string            `json:"Image"` // image tag, e.g. "paradedb/paradedb:v0.23.1"
+		Cmd    []string          `json:"Cmd"`
+		Env    []string          `json:"Env"`
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
 	HostConfig struct {
-		NanoCPUs int64 `json:"NanoCpus"`
-		Memory   int64 `json:"Memory"`
-		CPUQuota int64 `json:"CpuQuota"`
+		NanoCPUs    int64    `json:"NanoCpus"`
+		Memory      int64    `json:"Memory"`
+		CPUQuota    int64    `json:"CpuQuota"`
+		CapAdd      []string `json:"CapAdd"`
+		SecurityOpt []string `json:"SecurityOpt"`
+		NetworkMode string   `json:"NetworkMode"`
 	} `json:"HostConfig"`
+	Mounts []struct {
+		Type        string `json:"Type"`
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+		Mode        string `json:"Mode"`
+		RW          bool   `json:"RW"`
+	} `json:"Mounts"`
+	NetworkSettings struct {
+		Ports map[string][]struct {
+			HostIP   string `json:"HostIp"`
+			HostPort string `json:"HostPort"`
+		} `json:"Ports"`
+	} `json:"NetworkSettings"`
 }
 
-// captureContainerLimits fetches container resource limits from Docker API.
-func (c *Collector) captureContainerLimits(container string) bool {
+// captureContainerInfo fetches the docker inspect output and stores a curated
+// subset for the dashboard. Returns true on success.
+func (c *Collector) captureContainerInfo(container string) bool {
 	url := fmt.Sprintf("http://localhost/containers/%s/json", container)
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -409,28 +457,39 @@ func (c *Collector) captureContainerLimits(container string) bool {
 		return false
 	}
 
-	limits := make(map[string]interface{})
+	info := map[string]interface{}{
+		"image":        inspect.Config.Image,
+		"image_id":     inspect.Image,
+		"cmd":          inspect.Config.Cmd,
+		"env":          inspect.Config.Env,
+		"labels":       inspect.Config.Labels,
+		"mounts":       inspect.Mounts,
+		"network_mode": inspect.HostConfig.NetworkMode,
+		"ports":        inspect.NetworkSettings.Ports,
+		"host_config": map[string]interface{}{
+			"nano_cpus":    inspect.HostConfig.NanoCPUs,
+			"memory":       inspect.HostConfig.Memory,
+			"cpu_quota":    inspect.HostConfig.CPUQuota,
+			"cap_add":      inspect.HostConfig.CapAdd,
+			"security_opt": inspect.HostConfig.SecurityOpt,
+		},
+	}
 
-	// CPU limit (NanoCPUs is CPU limit * 1e9, or use CpuQuota/100000)
+	// Display-friendly limit strings for the existing UI.
 	if inspect.HostConfig.NanoCPUs > 0 {
 		cpuLimit := float64(inspect.HostConfig.NanoCPUs) / 1e9
-		limits["cpu_limit"] = fmt.Sprintf("%.1f cores", cpuLimit)
+		info["cpu_limit"] = fmt.Sprintf("%.1f cores", cpuLimit)
 	} else if inspect.HostConfig.CPUQuota > 0 {
 		cpuLimit := float64(inspect.HostConfig.CPUQuota) / 100000
-		limits["cpu_limit"] = fmt.Sprintf("%.1f cores", cpuLimit)
+		info["cpu_limit"] = fmt.Sprintf("%.1f cores", cpuLimit)
 	}
-
-	// Memory limit
 	if inspect.HostConfig.Memory > 0 {
 		memGB := float64(inspect.HostConfig.Memory) / (1024 * 1024 * 1024)
-		limits["memory_limit"] = fmt.Sprintf("%.1f GB", memGB)
+		info["memory_limit"] = fmt.Sprintf("%.1f GB", memGB)
 	}
 
-	if len(limits) > 0 {
-		containerLimitsMu.Lock()
-		ContainerLimits[container] = limits
-		containerLimitsMu.Unlock()
-		return true
-	}
-	return false
+	containerInfoMu.Lock()
+	containerInfo[container] = info
+	containerInfoMu.Unlock()
+	return true
 }


### PR DESCRIPTION

    Capture dataset.yaml and running k6 script in dashboard JSON

    loader pull now writes a small dataset.yaml at the dataset root recording
    the s3 source and pull timestamp. Absent file = local-only dataset.

    The k6 extension reads dataset.yaml at run time (if present) and auto-detects
    the running script's source by scanning os.Args for a .js/.ts/.mjs/.cjs path
    that exists on disk. Both are emitted in the dashboard JSON under top-level
    dataset_yaml, script, and script_path fields.

    Dashboard config modal gets Dataset and Script tabs that render only when
    their fields are present. The modal also opens for off-host backends now
    (empty container) whenever any global capture exists, so the script is
    reachable in those cases too.

    Drive-by: fix a JS ReferenceError where updateStats referenced data.backends
    but received only runs; pass backends explicitly. Trims the Container tab to
    identity (image, image_id, cpu_limit, memory_limit, cap_add, security_opt),
    cmd, and env — drops the duplicative/uninteresting mounts, ports, labels,
    network_mode, and raw host_config integers.

    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>