### PR TITLE
fix: quote table and column identifiers in Update() and ClickHouse Insert()

### DIFF
--- a/backends/clickhouse/driver.go
+++ b/backends/clickhouse/driver.go
@@ -103,9 +103,19 @@ func (d *Driver) Query(ctx context.Context, query string, args ...any) (int, err
 	return count, rows.Err()
 }
 
+// quoteClickHouseIdentifier returns a safely backtick-quoted ClickHouse identifier.
+// Backticks inside the name are escaped by doubling them.
+func quoteClickHouseIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
 // Insert bulk inserts rows using batch API.
 func (d *Driver) Insert(ctx context.Context, table string, cols []string, rows [][]any) (int, error) {
-	query := fmt.Sprintf("INSERT INTO %s (%s)", table, strings.Join(cols, ", "))
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = quoteClickHouseIdentifier(c)
+	}
+	query := fmt.Sprintf("INSERT INTO %s (%s)", quoteClickHouseIdentifier(table), strings.Join(quotedCols, ", "))
 
 	batch, err := d.conn.PrepareBatch(ctx, query)
 	if err != nil {

--- a/backends/shared/postgres/driver.go
+++ b/backends/shared/postgres/driver.go
@@ -136,12 +136,22 @@ func (d *Driver) Update(ctx context.Context, table string, keyCols []string, col
 		}
 	}
 
-	// Build: INSERT INTO t (cols) VALUES ($1,$2,...), ($3,$4,...) ON CONFLICT (keyCols) DO UPDATE SET col=EXCLUDED.col, ...
+	// Build: INSERT INTO "t" ("cols") VALUES ($1,$2,...), ($3,$4,...) ON CONFLICT ("keyCols") DO UPDATE SET "col"=EXCLUDED."col", ...
+	// Use pgx.Identifier.Sanitize() to safely quote each identifier, matching the pattern used by Insert().
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = pgx.Identifier{c}.Sanitize()
+	}
+	quotedKeyCols := make([]string, len(keyCols))
+	for i, c := range keyCols {
+		quotedKeyCols[i] = pgx.Identifier{c}.Sanitize()
+	}
+
 	var b strings.Builder
 	b.WriteString("INSERT INTO ")
-	b.WriteString(table)
+	b.WriteString(pgx.Identifier{table}.Sanitize())
 	b.WriteString(" (")
-	b.WriteString(strings.Join(cols, ", "))
+	b.WriteString(strings.Join(quotedCols, ", "))
 	b.WriteString(") VALUES ")
 
 	paramIdx := 1
@@ -163,15 +173,16 @@ func (d *Driver) Update(ctx context.Context, table string, keyCols []string, col
 	}
 
 	b.WriteString(" ON CONFLICT (")
-	b.WriteString(strings.Join(keyCols, ", "))
+	b.WriteString(strings.Join(quotedKeyCols, ", "))
 	b.WriteString(") DO UPDATE SET ")
 	for i, col := range valCols {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(col)
+		quotedCol := pgx.Identifier{col}.Sanitize()
+		b.WriteString(quotedCol)
 		b.WriteString(" = EXCLUDED.")
-		b.WriteString(col)
+		b.WriteString(quotedCol)
 	}
 
 	tag, err := d.pool.Exec(ctx, b.String(), args...)


### PR DESCRIPTION
## Summary

Security audit identified unquoted SQL identifiers in two driver methods that could allow SQL injection and would break on reserved keywords or mixed-case identifiers.

- **`backends/shared/postgres/driver.go` — `Update()`**: The method built `INSERT INTO t (cols) ... ON CONFLICT (keyCols) DO UPDATE SET col = EXCLUDED.col` by writing raw strings for the table name and all column names. Fixed by quoting every identifier with `pgx.Identifier{name}.Sanitize()`, which is exactly the pattern used by the sibling `Insert()` method (which passes `pgx.Identifier{table}` to `pgx.CopyFrom`).

- **`backends/clickhouse/driver.go` — `Insert()` (and `Update()` which delegates to it)**: Same issue — table and column names were interpolated unquoted into `fmt.Sprintf("INSERT INTO %s (%s)", table, ...)`. Fixed by adding a `quoteClickHouseIdentifier()` helper that wraps identifiers in backticks and escapes embedded backticks by doubling them (standard ClickHouse identifier quoting per the ClickHouse SQL syntax docs), and applying it to both the table and all column names.

## Changes

| File | Change |
|------|--------|
| `backends/shared/postgres/driver.go` | Quote `table` and all `cols`/`keyCols` in `Update()` using `pgx.Identifier{name}.Sanitize()` |
| `backends/clickhouse/driver.go` | Add `quoteClickHouseIdentifier()` helper; apply to `table` and all `cols` in `Insert()` |

## Test plan

- [x] `go build ./...` — passes with no errors
- [x] `gofmt -l backends/shared/postgres/driver.go backends/clickhouse/driver.go` — empty output (no formatting issues)
- [x] `go vet ./backends/...` — clean