### PR TITLE
ci: Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -14,6 +14,9 @@ concurrency:
   group: check-typo-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-typo:
     name: Check Typo using codespell

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -14,6 +14,9 @@ concurrency:
   group: lint-format-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-format:
     name: Lint File Endings & Trailing Whitespaces

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -18,6 +18,9 @@ concurrency:
   group: lint-markdown-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-markdown:
     name: Lint Markdown Files

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -18,6 +18,9 @@ concurrency:
   group: lint-yaml-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-yaml:
     name: Lint YAML Files


### PR DESCRIPTION
Every workflow lacking a `permissions:` block inherits the repository default for `GITHUB_TOKEN`, which is currently **write** across the org. That grants linters and test workflows push access they never use.

This adds a minimal top-level block to each workflow that had none:

- `contents: read` for linters, tests, and workflows that authenticate to external services with their own credentials
- elevated scopes only where the workflow demonstrably needs them (release publishing, issue creation)

Workflows that already declare workflow- or job-level permissions are untouched. Pure additions, no deletions.

This is a prerequisite for switching the org default workflow permissions to read-only — flipping that setting first would break the workflows that currently rely on implicit write.

Found via GitHub's Code Security assessment ("Workflow does not contain permissions", Medium, 35 findings), then audited across all non-archived, non-fork repos.

https://claude.ai/code/session_01Rg3UBFSnmKMPQLNpNKkn8d
