### PR TITLE
fix: Terminate exported dashboard JSON with a trailing newline

### DIFF
--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -305,7 +305,7 @@ func (o *Output) Stop() error {
 		base := fmt.Sprintf("dashboard_%s", time.Now().Format("2006-01-02_15-04-05"))
 
 		if o.exportJSON {
-			jsonData, err := json.MarshalIndent(data, "", "  ")
+			jsonData, err := marshalExportJSON(data)
 			if err == nil {
 				filename := base + ".json"
 				if err := os.WriteFile(filename, jsonData, 0644); err == nil {
@@ -819,6 +819,17 @@ func (o *Output) getSummary() map[string]interface{} {
 	}
 	addRunCaptures(out)
 	return out
+}
+
+// marshalExportJSON renders the export payload as indented JSON terminated by a
+// trailing newline. json.MarshalIndent stops at the closing brace, which trips
+// the end-of-file linters of repos these exports get committed to.
+func marshalExportJSON(data map[string]interface{}) ([]byte, error) {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(jsonData, '\n'), nil
 }
 
 // getExportData returns raw data for JSON export — no pre-aggregated timeline,

--- a/dashboard/output_export_test.go
+++ b/dashboard/output_export_test.go
@@ -1,11 +1,48 @@
 package dashboard
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestMarshalExportJSONEndsWithNewline(t *testing.T) {
+	data := map[string]interface{}{
+		"startTime": 1785149352318,
+		"runs":      map[string]interface{}{},
+	}
+
+	out, err := marshalExportJSON(data)
+	if err != nil {
+		t.Fatalf("marshal export json: %v", err)
+	}
+
+	if !bytes.HasSuffix(out, []byte("}\n")) {
+		t.Fatalf("expected export to end with a trailing newline, got %q", tail(out))
+	}
+	if bytes.HasSuffix(out, []byte("\n\n")) {
+		t.Fatalf("expected exactly one trailing newline, got %q", tail(out))
+	}
+
+	// The newline must not disturb the payload itself.
+	var round map[string]interface{}
+	if err := json.Unmarshal(out, &round); err != nil {
+		t.Fatalf("exported JSON no longer parses: %v", err)
+	}
+	if _, ok := round["startTime"]; !ok {
+		t.Fatalf("expected startTime to survive the round trip, got %v", round)
+	}
+}
+
+func tail(b []byte) string {
+	if len(b) > 12 {
+		b = b[len(b)-12:]
+	}
+	return string(b)
+}
 
 func TestExportStandaloneEscapesEmbeddedScriptTerminators(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

`--out dashboard` JSON exports now end with a trailing newline.

## Why

`json.MarshalIndent` stops at the closing brace and `os.WriteFile` writes those bytes verbatim, so every `dashboard_<timestamp>.json` export ended at `}` with no final newline.

These exports get committed to other repos. In `paradedb/website`, `public/benchmarks/topk_10_hn_text.json` was the only tracked file failing the `Lint Format` workflow's "Check for Missing Final Newlines" step, which broke that job on every open PR until it was patched by hand. Fixing it at the source stops each new export from reintroducing the problem.

## How

**`dashboard/output.go`**

- Extracted `marshalExportJSON`, which wraps `json.MarshalIndent(data, "", "  ")` and appends a single `'\n'`. Extracted rather than appended inline so the behavior is unit-testable — the export write itself lives inside `Stop()` and targets the working directory.
- `Stop()` export path now calls `marshalExportJSON(data)` instead of `json.MarshalIndent` directly.

**`dashboard/output_export_test.go`**

- Added `TestMarshalExportJSONEndsWithNewline`, asserting the payload ends with `}\n`, that there is exactly one trailing newline (not `\n\n`), and that the result still round-trips through `json.Unmarshal` with its keys intact.

The standalone HTML export was checked and needs no change: `dashboard/static/index.html` already ends with a newline, and the embedded-data `<script>` is injected before `</head>`, mid-document.

## Tests

- `go build ./...` passes
- `go test ./...` passes (all packages)
- `go vet ./dashboard/` clean, `gofmt -l dashboard/` clean
- Mutation-checked the new test: reverting the `append` to `return jsonData, nil` fails it with `expected export to end with a trailing newline, got "5149352318\n}"`, and restoring the fix passes
