### PR TITLE
bug: standalone HTML export dropping all query samples

### DIFF
--- a/dashboard/output.go
+++ b/dashboard/output.go
@@ -1081,39 +1081,53 @@ func buildTimeline(latencies []float64, timestamps []int64, hitCounts []int64, b
 }
 
 // JSON helper functions for untyped map access.
+// The json* helpers read a value that may arrive either as native Go types
+// (when aggregateExportData is handed getExportData()'s in-memory map, e.g. the
+// standalone `--out dashboard=html` export) or as json.Unmarshal types (when a
+// .json file is loaded, e.g. dashboard-viewer). Handle both, otherwise the
+// native-typed HTML path silently drops every sample (count=0, empty timeline).
 func jsonInt64(m map[string]interface{}, key string) int64 {
-	if v, ok := m[key].(float64); ok {
+	switch v := m[key].(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case float64:
 		return int64(v)
 	}
 	return 0
 }
 
 func jsonFloat64Slice(m map[string]interface{}, key string) []float64 {
-	arr, ok := m[key].([]interface{})
-	if !ok {
-		return nil
-	}
-	out := make([]float64, 0, len(arr))
-	for _, v := range arr {
-		if f, ok := v.(float64); ok {
-			out = append(out, f)
+	switch arr := m[key].(type) {
+	case []float64:
+		return arr
+	case []interface{}:
+		out := make([]float64, 0, len(arr))
+		for _, v := range arr {
+			if f, ok := v.(float64); ok {
+				out = append(out, f)
+			}
 		}
+		return out
 	}
-	return out
+	return nil
 }
 
 func jsonInt64Slice(m map[string]interface{}, key string) []int64 {
-	arr, ok := m[key].([]interface{})
-	if !ok {
-		return nil
-	}
-	out := make([]int64, 0, len(arr))
-	for _, v := range arr {
-		if f, ok := v.(float64); ok {
-			out = append(out, int64(f))
+	switch arr := m[key].(type) {
+	case []int64:
+		return arr
+	case []interface{}:
+		out := make([]int64, 0, len(arr))
+		for _, v := range arr {
+			if f, ok := v.(float64); ok {
+				out = append(out, int64(f))
+			}
 		}
+		return out
 	}
-	return out
+	return nil
 }
 
 func (o *Output) handleSSE(w http.ResponseWriter, r *http.Request) {

--- a/dashboard/output_test.go
+++ b/dashboard/output_test.go
@@ -183,3 +183,51 @@ func TestReadMetaEnvUnsetReturnsNil(t *testing.T) {
 		t.Fatalf("expected nil for unset env, got %v", m)
 	}
 }
+
+// The standalone `--out dashboard=html` export hands aggregateExportData the
+// in-memory getExportData() map, whose sample arrays are native Go slices
+// ([]float64/[]int64) and whose times are native int64, not json.Unmarshal's
+// []interface{}/float64. Regression: the json* helpers only accepted the
+// unmarshaled types, so every query sample was dropped (count=0, empty timeline)
+// while container CPU/mem still rendered.
+func TestAggregateExportDataHandlesNativeGoTypes(t *testing.T) {
+	const n = 100
+	start := int64(1_000_000)
+	lat := make([]float64, n)
+	ts := make([]int64, n)
+	hits := make([]int64, n)
+	for i := 0; i < n; i++ {
+		lat[i] = 2.0
+		ts[i] = start + int64(i)*100 // spread across a ~10s window
+		hits[i] = 10
+	}
+	rawData := map[string]interface{}{
+		"runs": map[string]interface{}{
+			"run1": map[string]interface{}{
+				"startTime": start,             // native int64, not float64
+				"endTime":   start + n*100 + 1, // native int64
+				"queries": map[string]interface{}{
+					"q1": map[string]interface{}{
+						"name":       "q1",
+						"vus":        1,
+						"executor":   "constant-vus",
+						"latencies":  lat,  // native []float64
+						"timestamps": ts,   // native []int64
+						"hitCounts":  hits, // native []int64
+						"query":      "SELECT 1",
+					},
+				},
+			},
+		},
+	}
+
+	out := aggregateExportData(rawData, time.Second, 0)
+	q := out["runs"].(map[string]interface{})["run1"].(map[string]interface{})["queries"].(map[string]interface{})["q1"].(map[string]interface{})
+
+	if got := q["count"].(int); got != n {
+		t.Fatalf("count = %d, want %d (native-typed samples were dropped)", got, n)
+	}
+	if tl, ok := q["timeline"].([]TimelinePoint); !ok || len(tl) == 0 {
+		t.Fatalf("timeline is empty; native-typed samples were dropped: %v", q["timeline"])
+	}
+}


### PR DESCRIPTION
The `--out dashboard=html` export feeds aggregateExportData the in-memory getExportData() map, whose sample arrays are native Go slices ([]float64, []int64) and whose times are native int64, not json.Unmarshal's []interface{} and float64. The json* helpers only accepted the unmarshaled types, so every query's latencies/timestamps were dropped: the standalone dashboard showed count=0 with an empty timeline (the main line), while container CPU/memory still rendered from a different code path.

Make jsonInt64/jsonFloat64Slice/jsonInt64Slice accept native Go types as well as the unmarshaled ones (dashboard-viewer/ServeFile still load from JSON). Add a regression test that runs native-typed data through aggregateExportData.


