### PR TITLE
fix: detect ParadeDB indexes

### DIFF
--- a/backends/paradedb/register.go
+++ b/backends/paradedb/register.go
@@ -33,14 +33,14 @@ func New(connString string) (backends.Driver, error) {
 	pgDriver.SetExtraQueries([]postgres.ConfigQuery{
 		// version_info() returns a composite record; cast so it scans as text
 		{Key: "paradedb.version", Query: "SELECT paradedb.version_info()::text"},
-		// Segment count of every BM25 index. Config capture runs at benchmark
+		// Segment count of every ParadeDB index. Config capture runs at benchmark
 		// setup, after the dataset load, so this is the run-start layout.
 		{Key: "segments_at_run_start", Query: `
 			SELECT 'paradedb.segments_at_run_start.' || c.relname,
 			       (SELECT count(*) FROM paradedb.index_info(c.oid::regclass))::text
 			FROM pg_class c
 			JOIN pg_am am ON c.relam = am.oid
-			WHERE am.amname = 'bm25'
+			WHERE am.amname = 'paradedb'
 			ORDER BY c.relname`},
 	})
 

--- a/datasets/sample/paradedb/post.sql
+++ b/datasets/sample/paradedb/post.sql
@@ -1,6 +1,6 @@
--- ParadeDB post-load: Create BM25 index
+-- ParadeDB post-load: Create ParadeDB index
 CREATE INDEX documents_search_idx ON documents
-USING bm25 (id, title, content)
+USING paradedb (id, title, content)
 WITH (key_field='id');
 
 VACUUM ANALYZE documents;

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -63,7 +63,7 @@ CREATE TABLE documents (
 );
 
 -- post.sql: Create indexes after load
-CREATE INDEX ON documents USING bm25 (content);
+CREATE INDEX ON documents USING paradedb (content);
 VACUUM ANALYZE documents;
 ```
 


### PR DESCRIPTION
Updates the ParadeDB backend catalog query to detect the `paradedb` access method, migrates the sample dataset to `USING paradedb`, and uses ParadeDB index terminology in current docs/comments.

Validation: `go test ./...` passes.