### PR TITLE
ci: use shared organization lint and check actions

### DIFF
--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -29,7 +29,7 @@ jobs:
       # The `skip` parameter is a total mess, read up before adding.
       # https://github.com/codespell-project/codespell/issues/1915
       - name: Check Typo
-        uses: paradedb/actions/check-typo@a024855293e56a720daa69e6648d023dd0cb9f77
+        uses: paradedb/actions/check-typo@b7703a0b117808acb8a659ca94be8ba274344289
         with:
           ignore-words-file: .codespellignore
           skip: ./go.sum,./datasets/sample/data.csv

--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -28,9 +28,8 @@ jobs:
 
       # The `skip` parameter is a total mess, read up before adding.
       # https://github.com/codespell-project/codespell/issues/1915
-      - name: Check Typo using codespell
-        uses: codespell-project/actions-codespell@v2
+      - name: Check Typo
+        uses: paradedb/actions/check-typo@a024855293e56a720daa69e6648d023dd0cb9f77
         with:
-          check_filenames: true
-          ignore_words_file: .codespellignore
-          skip: "./go.sum,./datasets/sample/data.csv"
+          ignore-words-file: .codespellignore
+          skip: ./go.sum,./datasets/sample/data.csv

--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -29,7 +29,7 @@ jobs:
       # The `skip` parameter is a total mess, read up before adding.
       # https://github.com/codespell-project/codespell/issues/1915
       - name: Check Typo
-        uses: paradedb/actions/check-typo@b7703a0b117808acb8a659ca94be8ba274344289
+        uses: paradedb/actions/check-typo@v12
         with:
           ignore-words-file: .codespellignore
           skip: ./go.sum,./datasets/sample/data.csv

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint Format
-        uses: paradedb/actions/lint-format@a024855293e56a720daa69e6648d023dd0cb9f77
+        uses: paradedb/actions/lint-format@b7703a0b117808acb8a659ca94be8ba274344289

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint Format
-        uses: paradedb/actions/lint-format@b7703a0b117808acb8a659ca94be8ba274344289
+        uses: paradedb/actions/lint-format@v12

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -26,34 +26,5 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
-      - name: Check for CRLF Files
-        run: |
-          FILES=$(git ls-files --eol | grep crlf || true)
-          if [[ ! -z "$FILES" ]]; then
-            echo "The following files have incorrect line endings:"
-            echo "$FILES"
-            false
-          fi
-
-      - name: Check for Trailing Whitespaces
-        run: |
-          FILES=$(git grep -Ilr '[[:blank:]]$' || true)
-          if [[ ! -z "$FILES" ]]; then
-            echo "The following files have trailing whitespaces:"
-            echo "$FILES"
-            exit 1
-          fi
-
-      - name: Check for Missing Final Newlines
-        run: |
-          MISSING=""
-          while IFS= read -r file; do
-            if [[ -s "$file" && -n "$(tail -c1 "$file")" ]]; then
-              MISSING="${MISSING}${file}"$'\n'
-            fi
-          done < <(git grep -Il '.')
-          if [[ -n "$MISSING" ]]; then
-            echo "The following files are missing a trailing newline:"
-            echo "$MISSING"
-            exit 1
-          fi
+      - name: Lint Format
+        uses: paradedb/actions/lint-format@a024855293e56a720daa69e6648d023dd0cb9f77

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint Markdown
-        uses: paradedb/actions/lint-prettier@a024855293e56a720daa69e6648d023dd0cb9f77
+        uses: paradedb/actions/lint-prettier@b7703a0b117808acb8a659ca94be8ba274344289
         with:
           patterns: "{**/*.md,**/*.mdx}"
           markdown: "true"

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -30,14 +30,9 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
-      - name: Set up NodeJS Environment
-        uses: actions/setup-node@v7
-
-      - name: Install Prettier and markdownlint
-        run: npm install -g prettier markdownlint-cli
-
-      - name: Run Markdown Lint
-        run: markdownlint "**/*.md"
-
-      - name: Run Prettier
-        run: prettier --check "{**/*.md,**/*.mdx}" --ignore-path .prettierignore
+      - name: Lint Markdown
+        uses: paradedb/actions/lint-prettier@a024855293e56a720daa69e6648d023dd0cb9f77
+        with:
+          patterns: "{**/*.md,**/*.mdx}"
+          markdown: "true"
+          ignore-path: .prettierignore

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint Markdown
-        uses: paradedb/actions/lint-prettier@b7703a0b117808acb8a659ca94be8ba274344289
+        uses: paradedb/actions/lint-prettier@v12
         with:
           patterns: "{**/*.md,**/*.mdx}"
           markdown: "true"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -23,6 +23,6 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: paradedb/actions/lint-pr-title@a024855293e56a720daa69e6648d023dd0cb9f77
+        uses: paradedb/actions/lint-pr-title@b7703a0b117808acb8a659ca94be8ba274344289
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -23,6 +23,6 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: paradedb/actions/lint-pr-title@b7703a0b117808acb8a659ca94be8ba274344289
+        uses: paradedb/actions/lint-pr-title@v12
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -24,5 +24,3 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: paradedb/actions/lint-pr-title@v12
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -23,6 +23,6 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: amannn/action-semantic-pull-request@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: paradedb/actions/lint-pr-title@a024855293e56a720daa69e6648d023dd0cb9f77
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -30,11 +30,7 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
-      - name: Set up NodeJS Environment
-        uses: actions/setup-node@v7
-
-      - name: Install Prettier
-        run: npm install -g prettier
-
-      - name: Check YAML Formatting
-        run: prettier --check "**/*.{yml,yaml}" --ignore-path .prettierignore
+      - name: Lint Yaml
+        uses: paradedb/actions/lint-prettier@a024855293e56a720daa69e6648d023dd0cb9f77
+        with:
+          ignore-path: .prettierignore

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint Yaml
-        uses: paradedb/actions/lint-prettier@a024855293e56a720daa69e6648d023dd0cb9f77
+        uses: paradedb/actions/lint-prettier@b7703a0b117808acb8a659ca94be8ba274344289
         with:
           ignore-path: .prettierignore

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint Yaml
-        uses: paradedb/actions/lint-prettier@b7703a0b117808acb8a659ca94be8ba274344289
+        uses: paradedb/actions/lint-prettier@v12
         with:
           ignore-path: .prettierignore


### PR DESCRIPTION
Replace duplicated CI steps with the shared composite actions in paradedb/actions#22, referenced by the `v12` release tag. Migrates: check-typo, lint-format, lint-markdown, lint-pr-title, lint-yaml.

Workflow triggers, job names, permissions, runners, concurrency, and checkout settings are preserved. Repository-specific exclusions, configuration files, and validation commands remain in this repository. Prettier/markdownlint versions are pinned directly in the shared install steps; repository dependencies are not installed for these checks. Spelling uses pinned Python codespell instead of the Docker wrapper, so the check no longer needs Docker Hub credentials. Bash checks handle tracked scripts and paths containing spaces; formatting preserves the prior glob scope, which skips hidden paths.

Depends on https://github.com/paradedb/actions/pull/22; merge the shared-actions PR and publish `v12` first. The tag does not exist yet, so consumer action resolution is expected to remain blocked until that release is published.

Validation: workflow/job-envelope and action-input checks, actionlint with ShellCheck, Prettier formatting, and git diff --check passed locally. The shared implementation passed 13 fixture/integration tests. Repository CI results are tracked separately.

Part of paradedb/paradedb#5477.

The migrated checks passed against the tested implementation SHA before switching to the requested release tag. Rerun CI after `v12` is published.
